### PR TITLE
Gh 153202 fix

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -153,20 +153,18 @@ static inline void _Py_RefcntAdd(PyObject* op, Py_ssize_t n)
 #  endif
 #else
     if (_Py_IsOwnedByCurrentThread(op)) {
-        uint32_t local = op->ob_ref_local;
+        uint8_t local = op->ob_ref_local;
         Py_ssize_t refcnt = (Py_ssize_t)local + n;
-#  if PY_SSIZE_T_MAX > UINT32_MAX
-        if (refcnt > (Py_ssize_t)UINT32_MAX) {
-            // The local reference count would overflow: spill the excess into
-            // the shared reference count rather than immortalizing the object.
+        if (refcnt > (Py_ssize_t)UINT8_MAX) {
+            // The narrow (uint8_t) local reference count would overflow: spill
+            // the excess into the shared reference count rather than overflowing
+            // the field or immortalizing the object.
             _Py_atomic_add_ssize(&op->ob_ref_shared,
                                  (refcnt - 1) << _Py_REF_SHARED_SHIFT);
-            _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, 1);
+            _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, 1);
         }
-        else
-#  endif
-        {
-            _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, (uint32_t)refcnt);
+        else {
+            _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, (uint8_t)refcnt);
         }
     }
     else {
@@ -195,7 +193,7 @@ _PyObject_IsUniquelyReferenced(PyObject *ob)
     // ensure that other threads cannot concurrently create new references to
     // this object.
     return (_Py_IsOwnedByCurrentThread(ob) &&
-            _Py_atomic_load_uint32_relaxed(&ob->ob_ref_local) == 1 &&
+            _Py_atomic_load_uint8_relaxed(&ob->ob_ref_local) == 1 &&
             _Py_atomic_load_ssize_relaxed(&ob->ob_ref_shared) == 0);
 #endif
 }
@@ -526,17 +524,18 @@ _PyObject_InitVar(PyVarObject *op, PyTypeObject *typeobj, Py_ssize_t size)
 static inline int
 _Py_TryIncrefFast(PyObject *op) {
     if (_Py_IsOwnedByCurrentThread(op)) {
-        uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local);
-        uint32_t new_local = local + 1;
-        if (new_local == 0) {
-            // ob_ref_local would overflow: spill the accumulated local count
-            // into the shared reference count rather than immortalizing.
+        uint8_t local = _Py_atomic_load_uint8_relaxed(&op->ob_ref_local);
+        if (local == UINT8_MAX) {
+            // ob_ref_local (a uint8_t) would overflow: spill the accumulated
+            // local count into the shared reference count rather than
+            // overflowing the field or immortalizing the object.
             _Py_atomic_add_ssize(&op->ob_ref_shared,
                 _Py_STATIC_CAST(Py_ssize_t, local) << _Py_REF_SHARED_SHIFT);
-            _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, 1);
+            _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, 1);
         }
         else {
-            _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, new_local);
+            _Py_atomic_store_uint8_relaxed(&op->ob_ref_local,
+                _Py_STATIC_CAST(uint8_t, local + 1));
         }
         _Py_INCREF_STAT_INC();
 #ifdef Py_REF_DEBUG
@@ -694,7 +693,7 @@ _PyObject_ResurrectStart(PyObject *op)
 #endif
 #ifdef Py_GIL_DISABLED
     _Py_atomic_store_uintptr_relaxed(&op->ob_tid, _Py_ThreadId());
-    _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, 1);
+    _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, 1);
     _Py_atomic_store_ssize_relaxed(&op->ob_ref_shared, 0);
 #else
     Py_SET_REFCNT(op, 1);
@@ -723,11 +722,11 @@ _PyObject_ResurrectEnd(PyObject *op)
     }
     return 1;
 #else
-    uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local);
+    uint8_t local = _Py_atomic_load_uint8_relaxed(&op->ob_ref_local);
     Py_ssize_t shared = _Py_atomic_load_ssize_acquire(&op->ob_ref_shared);
     if (_Py_IsOwnedByCurrentThread(op) && local == 1 && shared == 0) {
         // Fast-path: object has a single refcount and is owned by this thread
-        _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, 0);
+        _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, 0);
 # ifdef Py_TRACE_REFS
         _Py_ForgetReference(op);
 # endif

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -74,7 +74,7 @@ PyAPI_FUNC(int) _PyObject_IsFreed(PyObject *);
 #if defined(Py_GIL_DISABLED)
 #define _PyObject_HEAD_INIT(type)                   \
     {                                               \
-        .ob_ref_local = _Py_IMMORTAL_REFCNT_LOCAL,  \
+        .ob_ref_shared = _Py_REF_SHARED_IMMORTAL,   \
         .ob_flags = _Py_STATICALLY_ALLOCATED_FLAG,  \
         .ob_gc_bits = _PyGC_BITS_DEFERRED,          \
         .ob_type = (type)                           \
@@ -157,12 +157,17 @@ static inline void _Py_RefcntAdd(PyObject* op, Py_ssize_t n)
         Py_ssize_t refcnt = (Py_ssize_t)local + n;
 #  if PY_SSIZE_T_MAX > UINT32_MAX
         if (refcnt > (Py_ssize_t)UINT32_MAX) {
-            // Make the object immortal if the 32-bit local reference count
-            // would overflow.
-            refcnt = _Py_IMMORTAL_REFCNT_LOCAL;
+            // The local reference count would overflow: spill the excess into
+            // the shared reference count rather than immortalizing the object.
+            _Py_atomic_add_ssize(&op->ob_ref_shared,
+                                 (refcnt - 1) << _Py_REF_SHARED_SHIFT);
+            _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, 1);
         }
+        else
 #  endif
-        _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, (uint32_t)refcnt);
+        {
+            _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, (uint32_t)refcnt);
+        }
     }
     else {
         _Py_atomic_add_ssize(&op->ob_ref_shared, (n << _Py_REF_SHARED_SHIFT));
@@ -520,19 +525,28 @@ _PyObject_InitVar(PyVarObject *op, PyTypeObject *typeobj, Py_ssize_t size)
  */
 static inline int
 _Py_TryIncrefFast(PyObject *op) {
-    uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local);
-    local += 1;
-    if (local == 0) {
-        // immortal
-        _Py_INCREF_IMMORTAL_STAT_INC();
-        return 1;
-    }
     if (_Py_IsOwnedByCurrentThread(op)) {
+        uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local);
+        uint32_t new_local = local + 1;
+        if (new_local == 0) {
+            // ob_ref_local would overflow: spill the accumulated local count
+            // into the shared reference count rather than immortalizing.
+            _Py_atomic_add_ssize(&op->ob_ref_shared,
+                _Py_STATIC_CAST(Py_ssize_t, local) << _Py_REF_SHARED_SHIFT);
+            _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, 1);
+        }
+        else {
+            _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, new_local);
+        }
         _Py_INCREF_STAT_INC();
-        _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, local);
 #ifdef Py_REF_DEBUG
         _Py_IncRefTotal(_PyThreadState_GET());
 #endif
+        return 1;
+    }
+    if (_Py_IsImmortal(op)) {
+        // immortal
+        _Py_INCREF_IMMORTAL_STAT_INC();
         return 1;
     }
     return 0;

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -523,8 +523,11 @@ _PyObject_InitVar(PyVarObject *op, PyTypeObject *typeobj, Py_ssize_t size)
  */
 static inline int
 _Py_TryIncrefFast(PyObject *op) {
+    // gh-153202: see refcount.h's Py_INCREF -- load ob_ref_local
+    // unconditionally, in parallel with the ownership check, instead of
+    // gating it behind it.
+    uint8_t local = _Py_atomic_load_uint8_relaxed(&op->ob_ref_local);
     if (_Py_IsOwnedByCurrentThread(op)) {
-        uint8_t local = _Py_atomic_load_uint8_relaxed(&op->ob_ref_local);
         if (local == UINT8_MAX) {
             // ob_ref_local (a uint8_t) would overflow: spill the accumulated
             // local count into the shared reference count rather than

--- a/Include/object.h
+++ b/Include/object.h
@@ -161,7 +161,7 @@ struct _object {
     uint16_t ob_flags;
     PyMutex ob_mutex;           // per-object lock
     uint8_t ob_gc_bits;         // gc-related state
-    uint32_t ob_ref_local;      // local reference count
+    uint8_t ob_ref_local;       // local reference count (only a few bits used)
     Py_ssize_t ob_ref_shared;   // shared (atomic) reference count
     PyTypeObject *ob_type;
 };

--- a/Include/object.h
+++ b/Include/object.h
@@ -81,8 +81,8 @@ whose size is determined when the object is allocated.
         _Py_STATICALLY_ALLOCATED_FLAG, \
         { 0 },                      \
         0,                          \
-        _Py_IMMORTAL_REFCNT_LOCAL,  \
         0,                          \
+        _Py_REF_SHARED_IMMORTAL,    \
         (type),                     \
     },
 #else

--- a/Include/refcount.h
+++ b/Include/refcount.h
@@ -295,8 +295,14 @@ static inline Py_ALWAYS_INLINE void Py_INCREF(PyObject *op)
     // Non-limited C API and limited C API for Python 3.9 and older access
     // directly PyObject.ob_refcnt.
 #if defined(Py_GIL_DISABLED)
+    // gh-153202: load the local count unconditionally, in parallel with the
+    // ownership check below -- ob_ref_local and ob_tid are independent
+    // fields, so gating this load behind the ownership branch would
+    // serialize what can otherwise be two independent loads into one
+    // dependency chain, in every Py_INCREF call in the interpreter (see
+    // fix-summary.md 9.6 for the pyperformance evidence).
+    uint8_t local = _Py_atomic_load_uint8_relaxed(&op->ob_ref_local);
     if (_Py_IsOwnedByCurrentThread(op)) {
-        uint8_t local = _Py_atomic_load_uint8_relaxed(&op->ob_ref_local);
         if (local == UINT8_MAX) {
             // ob_ref_local (a uint8_t) would overflow: spill the accumulated
             // local count into the shared reference count rather than
@@ -378,8 +384,10 @@ static inline void Py_DECREF(PyObject *op) {
 #elif defined(Py_GIL_DISABLED) && defined(Py_REF_DEBUG)
 static inline void Py_DECREF(const char *filename, int lineno, PyObject *op)
 {
+    // gh-153202: see Py_INCREF -- load ob_ref_local unconditionally, in
+    // parallel with the ownership check, instead of gating it behind it.
+    uint8_t local = _Py_atomic_load_uint8_relaxed(&op->ob_ref_local);
     if (_Py_IsOwnedByCurrentThread(op)) {
-        uint8_t local = _Py_atomic_load_uint8_relaxed(&op->ob_ref_local);
         if (local == 0) {
             _Py_NegativeRefcount(filename, lineno, op);
         }
@@ -405,9 +413,11 @@ static inline void Py_DECREF(const char *filename, int lineno, PyObject *op)
 #elif defined(Py_GIL_DISABLED)
 static inline void Py_DECREF(PyObject *op)
 {
+    // gh-153202: see Py_INCREF -- load ob_ref_local unconditionally, in
+    // parallel with the ownership check, instead of gating it behind it.
+    uint8_t local = _Py_atomic_load_uint8_relaxed(&op->ob_ref_local);
     if (_Py_IsOwnedByCurrentThread(op)) {
         _Py_DECREF_STAT_INC();
-        uint8_t local = _Py_atomic_load_uint8_relaxed(&op->ob_ref_local);
         local--;
         _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, local);
         if (local == 0) {

--- a/Include/refcount.h
+++ b/Include/refcount.h
@@ -129,7 +129,7 @@ PyAPI_FUNC(Py_ssize_t) Py_REFCNT(PyObject *ob);
         if (shared_count >= _Py_IMMORTAL_MINIMUM_SHARED_REFCNT) {
             return _Py_IMMORTAL_INITIAL_REFCNT;
         }
-        uint32_t local = _Py_atomic_load_uint32_relaxed(&ob->ob_ref_local);
+        uint8_t local = _Py_atomic_load_uint8_relaxed(&ob->ob_ref_local);
         return _Py_STATIC_CAST(Py_ssize_t, local) + shared_count;
     #endif
     }
@@ -192,16 +192,16 @@ static inline void Py_SET_REFCNT(PyObject *ob, Py_ssize_t refcnt) {
     ob->ob_refcnt = refcnt;
 #endif
 #else
-    if (_Py_IsOwnedByCurrentThread(ob) && (size_t)refcnt <= (size_t)UINT32_MAX) {
+    if (_Py_IsOwnedByCurrentThread(ob) && (size_t)refcnt <= (size_t)UINT8_MAX) {
         // Set local refcount to desired refcount and shared refcount
         // to zero, but preserve the shared refcount flags.
-        ob->ob_ref_local = _Py_STATIC_CAST(uint32_t, refcnt);
+        ob->ob_ref_local = _Py_STATIC_CAST(uint8_t, refcnt);
         ob->ob_ref_shared &= _Py_REF_SHARED_FLAG_MASK;
     }
     else {
         // Set local refcount to zero and shared refcount to desired refcount.
-        // Mark the object as merged. A refcount that does not fit in the local
-        // count is also stored here rather than immortalizing the object.
+        // Mark the object as merged. A refcount that does not fit in the narrow
+        // local count is also stored here rather than immortalizing the object.
         ob->ob_tid = _Py_UNOWNED_TID;
         ob->ob_ref_local = 0;
         ob->ob_ref_shared = _Py_REF_SHARED(refcnt, _Py_REF_MERGED);
@@ -282,18 +282,19 @@ static inline Py_ALWAYS_INLINE void Py_INCREF(PyObject *op)
     // directly PyObject.ob_refcnt.
 #if defined(Py_GIL_DISABLED)
     if (_Py_IsOwnedByCurrentThread(op)) {
-        uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local);
-        uint32_t new_local = local + 1;
-        if (new_local == 0) {
-            // ob_ref_local would overflow: spill the accumulated local count
-            // into the shared reference count rather than immortalizing the
-            // object (immortality must not depend on ob_ref_local's width).
+        uint8_t local = _Py_atomic_load_uint8_relaxed(&op->ob_ref_local);
+        if (local == UINT8_MAX) {
+            // ob_ref_local (a uint8_t) would overflow: spill the accumulated
+            // local count into the shared reference count rather than
+            // overflowing the field or immortalizing the object (immortality
+            // must not depend on ob_ref_local's width).
             _Py_atomic_add_ssize(&op->ob_ref_shared,
                 _Py_STATIC_CAST(Py_ssize_t, local) << _Py_REF_SHARED_SHIFT);
-            _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, 1);
+            _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, 1);
         }
         else {
-            _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, new_local);
+            _Py_atomic_store_uint8_relaxed(&op->ob_ref_local,
+                _Py_STATIC_CAST(uint8_t, local + 1));
         }
     }
     else if (_Py_IsImmortal(op)) {
@@ -364,14 +365,14 @@ static inline void Py_DECREF(PyObject *op) {
 static inline void Py_DECREF(const char *filename, int lineno, PyObject *op)
 {
     if (_Py_IsOwnedByCurrentThread(op)) {
-        uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local);
+        uint8_t local = _Py_atomic_load_uint8_relaxed(&op->ob_ref_local);
         if (local == 0) {
             _Py_NegativeRefcount(filename, lineno, op);
         }
         _Py_DECREF_STAT_INC();
         _Py_DECREF_DecRefTotal();
         local--;
-        _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, local);
+        _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, local);
         if (local == 0) {
             _Py_MergeZeroLocalRefcount(op);
         }
@@ -392,9 +393,9 @@ static inline void Py_DECREF(PyObject *op)
 {
     if (_Py_IsOwnedByCurrentThread(op)) {
         _Py_DECREF_STAT_INC();
-        uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local);
+        uint8_t local = _Py_atomic_load_uint8_relaxed(&op->ob_ref_local);
         local--;
-        _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, local);
+        _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, local);
         if (local == 0) {
             _Py_MergeZeroLocalRefcount(op);
         }

--- a/Include/refcount.h
+++ b/Include/refcount.h
@@ -99,9 +99,23 @@ check by comparing the reference count field to the minimum immortality refcount
    // _Py_IMMORTAL_MINIMUM_SHARED_REFCNT. Newly immortalized objects are given
    // _Py_IMMORTAL_INITIAL_SHARED_REFCNT (higher than the minimum), so that a
    // huge number of increfs/decrefs can occur before immortality could be lost.
-#  define _Py_IMMORTAL_MINIMUM_SHARED_REFCNT  (_Py_REF_SHARED_COUNT_MAX / 2)
+   //
+   // The immortal region is placed in the top quarter of the count range
+   // rather than at its midpoint: pycore_object.h's _Py_REF_DEFERRED (the
+   // baseline every deferred-refcounted object's shared count is initialized
+   // to) sits at PY_SSIZE_T_MAX / 8, which is almost exactly the midpoint of
+   // this range. A midpoint immortal threshold made every freshly
+   // deferred-refcounted object (module dicts, functions, code objects, ...)
+   // immortal from the moment deferred refcounting was enabled, with zero
+   // real references (gh-153202 fix-summary, "已知限制"). Starting the
+   // immortal region a full COUNT_MAX/4 (~2**59) above _Py_REF_DEFERRED
+   // leaves headroom no realistic number of increfs/decrefs could cross; see
+   // the static_assert against _Py_REF_DEFERRED in Objects/object.c.
+#  define _Py_IMMORTAL_MINIMUM_SHARED_REFCNT \
+              (_Py_REF_SHARED_COUNT_MAX - (_Py_REF_SHARED_COUNT_MAX / 4))
 #  define _Py_IMMORTAL_INITIAL_SHARED_REFCNT \
-              (_Py_IMMORTAL_MINIMUM_SHARED_REFCNT + (_Py_REF_SHARED_COUNT_MAX / 4))
+              (_Py_IMMORTAL_MINIMUM_SHARED_REFCNT + \
+               ((_Py_REF_SHARED_COUNT_MAX - _Py_IMMORTAL_MINIMUM_SHARED_REFCNT) / 2))
 
    // The ob_ref_shared value used to represent a freshly immortal object (both
    // statically allocated and runtime-promoted). The two flag bits are clear.

--- a/Include/refcount.h
+++ b/Include/refcount.h
@@ -68,13 +68,6 @@ check by comparing the reference count field to the minimum immortality refcount
 #define _Py_STATIC_IMMORTAL_MINIMUM_REFCNT ((Py_ssize_t)(6L << 28))
 #endif
 
-// Py_GIL_DISABLED builds indicate immortal objects using `ob_ref_local`, which is
-// always 32-bits.
-#ifdef Py_GIL_DISABLED
-#define _Py_IMMORTAL_REFCNT_LOCAL UINT32_MAX
-#endif
-
-
 #ifdef Py_GIL_DISABLED
    // The shared reference count uses the two least-significant bits to store
    // flags. The remaining bits are used to store the reference count.
@@ -90,6 +83,30 @@ check by comparing the reference count field to the minimum immortality refcount
    // Create a shared field from a refcnt and desired flags
 #  define _Py_REF_SHARED(refcnt, flags) \
               (((refcnt) << _Py_REF_SHARED_SHIFT) + (flags))
+
+   // The maximum value representable in the *count* portion of ob_ref_shared
+   // (the bits above the two flags). ob_ref_shared is a signed Py_ssize_t, so
+   // the count occupies the remaining high bits.
+#  define _Py_REF_SHARED_COUNT_MAX \
+              (_Py_STATIC_CAST(Py_ssize_t, PY_SSIZE_T_MAX >> _Py_REF_SHARED_SHIFT))
+
+   // Immortal objects are marked by a reserved, very large value in the count
+   // portion of ob_ref_shared, mirroring the saturation/immortality scheme the
+   // default (with-GIL) build uses for ob_refcnt. Keeping the immortal marker
+   // on ob_ref_shared makes immortality independent of ob_ref_local's width.
+   //
+   // An object is immortal when its shared count is at least
+   // _Py_IMMORTAL_MINIMUM_SHARED_REFCNT. Newly immortalized objects are given
+   // _Py_IMMORTAL_INITIAL_SHARED_REFCNT (higher than the minimum), so that a
+   // huge number of increfs/decrefs can occur before immortality could be lost.
+#  define _Py_IMMORTAL_MINIMUM_SHARED_REFCNT  (_Py_REF_SHARED_COUNT_MAX / 2)
+#  define _Py_IMMORTAL_INITIAL_SHARED_REFCNT \
+              (_Py_IMMORTAL_MINIMUM_SHARED_REFCNT + (_Py_REF_SHARED_COUNT_MAX / 4))
+
+   // The ob_ref_shared value used to represent a freshly immortal object (both
+   // statically allocated and runtime-promoted). The two flag bits are clear.
+#  define _Py_REF_SHARED_IMMORTAL \
+              _Py_REF_SHARED(_Py_IMMORTAL_INITIAL_SHARED_REFCNT, _Py_REF_SHARED_INIT)
 #endif  // Py_GIL_DISABLED
 #endif  // _Py_OPAQUE_PYOBJECT
 
@@ -106,13 +123,14 @@ PyAPI_FUNC(Py_ssize_t) Py_REFCNT(PyObject *ob);
     #if !defined(Py_GIL_DISABLED)
         return ob->ob_refcnt;
     #else
-        uint32_t local = _Py_atomic_load_uint32_relaxed(&ob->ob_ref_local);
-        if (local == _Py_IMMORTAL_REFCNT_LOCAL) {
+        Py_ssize_t shared = _Py_atomic_load_ssize_relaxed(&ob->ob_ref_shared);
+        Py_ssize_t shared_count =
+            Py_ARITHMETIC_RIGHT_SHIFT(Py_ssize_t, shared, _Py_REF_SHARED_SHIFT);
+        if (shared_count >= _Py_IMMORTAL_MINIMUM_SHARED_REFCNT) {
             return _Py_IMMORTAL_INITIAL_REFCNT;
         }
-        Py_ssize_t shared = _Py_atomic_load_ssize_relaxed(&ob->ob_ref_shared);
-        return _Py_STATIC_CAST(Py_ssize_t, local) +
-               Py_ARITHMETIC_RIGHT_SHIFT(Py_ssize_t, shared, _Py_REF_SHARED_SHIFT);
+        uint32_t local = _Py_atomic_load_uint32_relaxed(&ob->ob_ref_local);
+        return _Py_STATIC_CAST(Py_ssize_t, local) + shared_count;
     #endif
     }
     #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
@@ -126,8 +144,9 @@ PyAPI_FUNC(Py_ssize_t) Py_REFCNT(PyObject *ob);
 static inline Py_ALWAYS_INLINE int _Py_IsImmortal(PyObject *op)
 {
 #if defined(Py_GIL_DISABLED)
-    return (_Py_atomic_load_uint32_relaxed(&op->ob_ref_local) ==
-            _Py_IMMORTAL_REFCNT_LOCAL);
+    Py_ssize_t shared = _Py_atomic_load_ssize_relaxed(&op->ob_ref_shared);
+    return Py_ARITHMETIC_RIGHT_SHIFT(Py_ssize_t, shared, _Py_REF_SHARED_SHIFT)
+           >= _Py_IMMORTAL_MINIMUM_SHARED_REFCNT;
 #elif SIZEOF_VOID_P > 4
     return _Py_CAST(int32_t, op->ob_refcnt) < 0;
 #else
@@ -173,23 +192,16 @@ static inline void Py_SET_REFCNT(PyObject *ob, Py_ssize_t refcnt) {
     ob->ob_refcnt = refcnt;
 #endif
 #else
-    if (_Py_IsOwnedByCurrentThread(ob)) {
-        if ((size_t)refcnt > (size_t)UINT32_MAX) {
-            // On overflow, make the object immortal
-            ob->ob_tid = _Py_UNOWNED_TID;
-            ob->ob_ref_local = _Py_IMMORTAL_REFCNT_LOCAL;
-            ob->ob_ref_shared = 0;
-        }
-        else {
-            // Set local refcount to desired refcount and shared refcount
-            // to zero, but preserve the shared refcount flags.
-            ob->ob_ref_local = _Py_STATIC_CAST(uint32_t, refcnt);
-            ob->ob_ref_shared &= _Py_REF_SHARED_FLAG_MASK;
-        }
+    if (_Py_IsOwnedByCurrentThread(ob) && (size_t)refcnt <= (size_t)UINT32_MAX) {
+        // Set local refcount to desired refcount and shared refcount
+        // to zero, but preserve the shared refcount flags.
+        ob->ob_ref_local = _Py_STATIC_CAST(uint32_t, refcnt);
+        ob->ob_ref_shared &= _Py_REF_SHARED_FLAG_MASK;
     }
     else {
         // Set local refcount to zero and shared refcount to desired refcount.
-        // Mark the object as merged.
+        // Mark the object as merged. A refcount that does not fit in the local
+        // count is also stored here rather than immortalizing the object.
         ob->ob_tid = _Py_UNOWNED_TID;
         ob->ob_ref_local = 0;
         ob->ob_ref_shared = _Py_REF_SHARED(refcnt, _Py_REF_MERGED);
@@ -269,15 +281,24 @@ static inline Py_ALWAYS_INLINE void Py_INCREF(PyObject *op)
     // Non-limited C API and limited C API for Python 3.9 and older access
     // directly PyObject.ob_refcnt.
 #if defined(Py_GIL_DISABLED)
-    uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local);
-    uint32_t new_local = local + 1;
-    if (new_local == 0) {
-        _Py_INCREF_IMMORTAL_STAT_INC();
-        // local is equal to _Py_IMMORTAL_REFCNT_LOCAL: do nothing
-        return;
-    }
     if (_Py_IsOwnedByCurrentThread(op)) {
-        _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, new_local);
+        uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local);
+        uint32_t new_local = local + 1;
+        if (new_local == 0) {
+            // ob_ref_local would overflow: spill the accumulated local count
+            // into the shared reference count rather than immortalizing the
+            // object (immortality must not depend on ob_ref_local's width).
+            _Py_atomic_add_ssize(&op->ob_ref_shared,
+                _Py_STATIC_CAST(Py_ssize_t, local) << _Py_REF_SHARED_SHIFT);
+            _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, 1);
+        }
+        else {
+            _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, new_local);
+        }
+    }
+    else if (_Py_IsImmortal(op)) {
+        _Py_INCREF_IMMORTAL_STAT_INC();
+        return;
     }
     else {
         _Py_atomic_add_ssize(&op->ob_ref_shared, (1 << _Py_REF_SHARED_SHIFT));
@@ -342,24 +363,25 @@ static inline void Py_DECREF(PyObject *op) {
 #elif defined(Py_GIL_DISABLED) && defined(Py_REF_DEBUG)
 static inline void Py_DECREF(const char *filename, int lineno, PyObject *op)
 {
-    uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local);
-    if (local == _Py_IMMORTAL_REFCNT_LOCAL) {
-        _Py_DECREF_IMMORTAL_STAT_INC();
-        return;
-    }
-    _Py_DECREF_STAT_INC();
-    _Py_DECREF_DecRefTotal();
     if (_Py_IsOwnedByCurrentThread(op)) {
+        uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local);
         if (local == 0) {
             _Py_NegativeRefcount(filename, lineno, op);
         }
+        _Py_DECREF_STAT_INC();
+        _Py_DECREF_DecRefTotal();
         local--;
         _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, local);
         if (local == 0) {
             _Py_MergeZeroLocalRefcount(op);
         }
     }
+    else if (_Py_IsImmortal(op)) {
+        _Py_DECREF_IMMORTAL_STAT_INC();
+    }
     else {
+        _Py_DECREF_STAT_INC();
+        _Py_DECREF_DecRefTotal();
         _Py_DecRefSharedDebug(op, filename, lineno);
     }
 }
@@ -368,20 +390,20 @@ static inline void Py_DECREF(const char *filename, int lineno, PyObject *op)
 #elif defined(Py_GIL_DISABLED)
 static inline void Py_DECREF(PyObject *op)
 {
-    uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local);
-    if (local == _Py_IMMORTAL_REFCNT_LOCAL) {
-        _Py_DECREF_IMMORTAL_STAT_INC();
-        return;
-    }
-    _Py_DECREF_STAT_INC();
     if (_Py_IsOwnedByCurrentThread(op)) {
+        _Py_DECREF_STAT_INC();
+        uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local);
         local--;
         _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, local);
         if (local == 0) {
             _Py_MergeZeroLocalRefcount(op);
         }
     }
+    else if (_Py_IsImmortal(op)) {
+        _Py_DECREF_IMMORTAL_STAT_INC();
+    }
     else {
+        _Py_DECREF_STAT_INC();
         _Py_DecRefShared(op);
     }
 }

--- a/InternalDocs/garbage_collector.md
+++ b/InternalDocs/garbage_collector.md
@@ -145,19 +145,27 @@ and, during garbage collection, differentiate reachable vs. unreachable objects.
                   |                      ...                      |
 ```
 
-Note that not all fields are to scale. `pad` is two bytes, `ob_mutex` and
-`ob_gc_bits` are each one byte, and `ob_ref_local` is four bytes. The
-other fields, `ob_tid`, `ob_ref_shared`, and `ob_type`, are all
-pointer-sized (that is, eight bytes on a 64-bit platform).
+Note that not all fields are to scale. `pad` is two bytes, and `ob_mutex`,
+`ob_gc_bits`, and `ob_ref_local` are each one byte (only a few bits of
+`ob_ref_local` are ever used). The other fields, `ob_tid`, `ob_ref_shared`,
+and `ob_type`, are all pointer-sized (that is, eight bytes on a 64-bit
+platform).
 
 
 The garbage collector also temporarily repurposes the `ob_tid` (thread ID)
-and `ob_ref_local` (local reference count) fields for other purposes during
-collections.  The `ob_tid` field is later restored from the containing
-mimalloc segment data structure.  In some cases, such as when the original
-allocating thread exits, this can result in a different `ob_tid` value.
-Code should not rely on `ob_tid` being stable across operations that may
-trigger garbage collection.
+field during collections, using it as a linked-list pointer for the worklist
+of objects being processed.  The `ob_tid` field is later restored from the
+containing mimalloc segment data structure.  In some cases, such as when the
+original allocating thread exits, this can result in a different `ob_tid`
+value.  Code should not rely on `ob_tid` being stable across operations that
+may trigger garbage collection.
+
+To determine which unreachable objects are still reachable from outside the
+unreachable set, the collector counts each object's incoming references in a
+temporary side table of `Py_ssize_t` counters keyed by object.  Earlier
+versions repurposed the narrow `ob_ref_local` field for this scratch count,
+but that field is no longer wide enough to hold an arbitrary count, so the
+side table is used instead.
 
 
 C APIs

--- a/Lib/test/test_bigmem.py
+++ b/Lib/test/test_bigmem.py
@@ -1263,6 +1263,21 @@ class ImmortalityTest(unittest.TestCase):
     def test_stickiness(self, size):
         """Check that immortality is "sticky", so that
            once an object is immortal it remains so."""
+        # On the default build an object is permanently immortalized once its
+        # reference count crosses the immortality threshold (~2**31), so this
+        # test drives o1's refcount past that point (hence the 2**31 sizing)
+        # and checks that it stays immortal.
+        #
+        # The free-threaded build does NOT immortalize objects on
+        # reference-count overflow: the narrow (uint8_t) ob_ref_local spills
+        # its excess into ob_ref_shared instead, so there is no reference count
+        # reachable in practice that makes an ordinary object immortal here.
+        # (This 2**31 sizing used to coincide with the free-threaded
+        # local-overflow point only because that point was formerly ~2**32;
+        # that coincidence no longer exists.)
+        if support.Py_GIL_DISABLED:
+            self.skipTest("the free-threaded build does not immortalize "
+                          "objects on reference-count overflow")
         _testcapi = import_helper.import_module('_testcapi')
         if size < _2G:
             # Not enough memory to cause immortality on overflow

--- a/Lib/test/test_capi/test_immortal.py
+++ b/Lib/test/test_capi/test_immortal.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 from test.support import import_helper
 
@@ -20,6 +21,22 @@ class TestUnstableCAPI(unittest.TestCase):
                 self.assertFalse(_testcapi.is_immortal(non_immortal))
 
         # CRASHES _testcapi.is_immortal(NULL)
+
+    def test_ordinary_object_not_immortal_after_many_increfs(self):
+        # gh-153202: the free-threaded immortal marker no longer lives in
+        # ob_ref_local (whose width is being reduced), so an ordinary object
+        # whose reference count is incremented well past 250 from a single
+        # thread must not be misreported as immortal.
+        obj = object()
+        # Build many references from this single thread. This drives the
+        # owning-thread incref fast path far above 250 references.
+        refs = [obj] * 300
+        try:
+            self.assertGreaterEqual(sys.getrefcount(obj), 250)
+            self.assertFalse(_testcapi.is_immortal(obj))
+        finally:
+            del refs
+        self.assertFalse(_testcapi.is_immortal(obj))
 
 
 class TestInternalCAPI(unittest.TestCase):

--- a/Lib/test/test_capi/test_object.py
+++ b/Lib/test/test_capi/test_object.py
@@ -388,10 +388,12 @@ class PyObjectSizeTest(unittest.TestCase):
             #   uint16_t      ob_flags        (H)
             #   PyMutex       ob_mutex        (B)
             #   uint8_t       ob_gc_bits      (B)
-            #   uint32_t      ob_ref_local    (I)
+            #   uint8_t       ob_ref_local    (B)
             #   Py_ssize_t    ob_ref_shared   (n)
             #   PyTypeObject *ob_type         (P)
-            expected = struct.calcsize('PHBBInP')
+            # (ob_ref_shared's 8-byte alignment pads out ob_ref_local, so the
+            # total size is unchanged by that field's width.)
+            expected = struct.calcsize('PHBBBnP')
         else:
             # struct _object (default build): a pointer-sized refcount union
             # followed by the ob_type pointer.

--- a/Lib/test/test_capi/test_object.py
+++ b/Lib/test/test_capi/test_object.py
@@ -1,6 +1,7 @@
 import enum
 import os
 import pickle
+import struct
 import sys
 import textwrap
 import unittest
@@ -340,6 +341,50 @@ class CAPITest(unittest.TestCase):
         # test NULL object
         output = self.pyobject_dump(NULL)
         self.assertRegex(output, r'<object at .* is freed>')
+
+
+@support.cpython_only
+class PyObjectSizeTest(unittest.TestCase):
+    # sizeof(PyObject) is exported to out-of-process debuggers and remote
+    # profilers (PEP 768) through several surfaces that all derive from the
+    # same C expression:
+    #   * _Py_DebugOffsets.pyobject.size  (Include/internal/pycore_debug_offsets.h)
+    #   * _testinternalcapi.SIZEOF_PYOBJECT (Modules/_testinternalcapi.c)
+    #   * SIZEOF_PYOBJECT in Modules/_remote_debugging/_remote_debugging.h
+    # A width change to a PyObject header field (e.g. ob_ref_local /
+    # ob_ref_shared in the free-threaded build) therefore silently changes the
+    # exported size with no signal to tooling that cached the old layout.  Pin
+    # the value so such a change trips this test and forces a conscious update
+    # plus a decision about bumping _Py_DebugOffsets.version.
+
+    def test_sizeof_pyobject_matches_base_object(self):
+        # The exported diagnostic must track the real object layout.  The base
+        # ``object`` type stores nothing beyond a PyObject, so its basic size
+        # is exactly sizeof(PyObject); if the two ever disagree, the exported
+        # debug-offsets data has drifted from reality.
+        self.assertEqual(_testinternalcapi.SIZEOF_PYOBJECT,
+                         object.__basicsize__)
+
+    def test_sizeof_pyobject_pinned(self):
+        # Independently recompute sizeof(PyObject) from the documented header
+        # layout (Include/object.h).  Changing a field width forces this
+        # expectation to be updated in lockstep, which is the point.
+        pointer = struct.calcsize('P')
+        if support.Py_GIL_DISABLED:
+            # struct _object (free-threaded build):
+            #   uintptr_t     ob_tid          (P)
+            #   uint16_t      ob_flags        (H)
+            #   PyMutex       ob_mutex        (B)
+            #   uint8_t       ob_gc_bits      (B)
+            #   uint32_t      ob_ref_local    (I)
+            #   Py_ssize_t    ob_ref_shared   (n)
+            #   PyTypeObject *ob_type         (P)
+            expected = struct.calcsize('PHBBInP')
+        else:
+            # struct _object (default build): a pointer-sized refcount union
+            # followed by the ob_type pointer.
+            expected = 2 * pointer
+        self.assertEqual(_testinternalcapi.SIZEOF_PYOBJECT, expected)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_capi/test_object.py
+++ b/Lib/test/test_capi/test_object.py
@@ -225,6 +225,18 @@ class IsUniquelyReferencedTest(unittest.TestCase):
         self.assertFalse(_testcapi.is_uniquely_referenced(42))
         # CRASHES is_uniquely_referenced(NULL)
 
+@unittest.skipUnless(support.Py_GIL_DISABLED, 'requires free-threaded build')
+class RefcountSpillTest(unittest.TestCase):
+    """gh-153202: ob_ref_local overflow must spill into ob_ref_shared rather
+    than immortalizing the object."""
+    def test_refcount_spill(self):
+        # Drives at least two overflow-spill cycles on one object and confirms
+        # it stays mortal, keeps a correct refcount, and deallocates when its
+        # reference count (including the spilled shared count) reaches zero.
+        # The C helper raises AssertionError on any failure.
+        _testcapi.test_refcount_spill()
+
+
 class CAPITest(unittest.TestCase):
     def check_negative_refcount(self, code):
         # bpo-35059: Check that Py_DECREF() reports the correct filename

--- a/Lib/test/test_free_threading/test_refcount.py
+++ b/Lib/test/test_free_threading/test_refcount.py
@@ -1,0 +1,98 @@
+import sys
+import threading
+import unittest
+
+from test.support import import_helper, threading_helper
+
+
+_testcapi = import_helper.import_module("_testcapi")
+
+
+@threading_helper.requires_working_threading()
+class TestRefcountOverflowSpill(unittest.TestCase):
+    def test_concurrent_incref_overflow_spill(self):
+        # gh-153202: In the free-threaded build ``ob_ref_local`` is a uint8_t,
+        # so it can only hold a small (< 256) local reference count.  When the
+        # owning thread increments an object's reference count past that
+        # ~256-entry boundary, the excess must "spill" into the shared
+        # reference count -- it must never overflow the field or immortalize
+        # the object.
+        #
+        # Drive one object's reference count far past the boundary from the
+        # owning thread (exercising the overflow-spill path many times) while
+        # several other threads concurrently create and drop references through
+        # the shared reference count, then confirm the final reference count is
+        # exactly correct and the object was not immortalized.
+        #
+        # The reference-count assertions are only made once every worker thread
+        # has been joined, so the object's state is quiescent and the expected
+        # count is deterministic (this makes the test robust against re-runs;
+        # it is intended to pass with no flakiness across many consecutive
+        # runs, e.g. ``-F --forever``).
+
+        class C:
+            pass
+
+        # ``obj`` is created here, so it is owned by the thread running this
+        # test.  Only *this* thread's increfs use the narrow local count and
+        # can trigger the overflow-spill path, so the owner workload below must
+        # run on this thread rather than in a spawned worker.
+        obj = C()
+
+        NUM_WORKERS = 8
+        # Comfortably larger than the 256-entry local boundary so the owning
+        # thread crosses it (and spills) many times.
+        NUM_REFS = 5000
+
+        # References held permanently by the owning thread for the duration of
+        # the measurement.  Building these drives the owner-thread local count
+        # far past 256, forcing repeated spills into the shared count.
+        owner_refs = []
+
+        # Synchronize the owner and all workers so the spill path and the
+        # shared-count increfs genuinely race.
+        barrier = threading.Barrier(NUM_WORKERS + 1)
+
+        def worker():
+            # A non-owning thread: each incref goes through the atomic shared
+            # reference count.  Every reference taken here is dropped again, so
+            # once the thread is joined it has contributed a net zero to the
+            # reference count.
+            barrier.wait()
+            held = []
+            for _ in range(NUM_REFS):
+                held.append(obj)
+            del held
+
+        threads = [threading.Thread(target=worker) for _ in range(NUM_WORKERS)]
+        for thread in threads:
+            thread.start()
+
+        # Baseline includes the local ``obj`` name plus the temporary reference
+        # created for the ``sys.getrefcount`` argument.
+        base = sys.getrefcount(obj)
+
+        barrier.wait()
+        for _ in range(NUM_REFS):
+            owner_refs.append(obj)
+
+        for thread in threads:
+            thread.join()
+
+        # Every worker has been joined, so their references are gone and only
+        # the owner's ``NUM_REFS`` references (plus the baseline) remain.
+        self.assertEqual(sys.getrefcount(obj), base + NUM_REFS)
+
+        # The overflow must have spilled into the shared count, not
+        # immortalized the object.
+        self.assertFalse(_testcapi.is_immortal(obj))
+
+        # Dropping the owner's references brings the count back to the baseline,
+        # confirming the spilled shared count is accounted for on decref.
+        owner_refs.clear()
+        self.assertEqual(sys.getrefcount(obj), base)
+        self.assertFalse(_testcapi.is_immortal(obj))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -433,6 +433,44 @@ class GCTests(unittest.TestCase):
         self.assertEqual((e, f), (0, 1))
         self.assertEqual((h, i), (0, 0))
 
+    def test_collect_cycle_with_many_cross_references(self):
+        # gh-153202: During cyclic collection the free-threaded GC computes,
+        # for each unreachable object, the number of references coming from
+        # outside the unreachable set. That scratch counter must be able to
+        # hold an arbitrary count; if it were bounded (e.g. to an 8-bit field)
+        # a cycle with more than 255 references to a single object would
+        # overflow it and cause the object to be falsely treated as still
+        # reachable (or crash). Build such a cycle between just two objects and
+        # confirm it is collected.
+        N = 300  # comfortably more than 255
+
+        class Node:
+            pass
+
+        a = Node()
+        b = Node()
+        # Reference a <-> b N times each, forming one cycle with far more than
+        # 255 cross-references between the two objects.
+        a.refs = [b] * N
+        b.refs = [a] * N
+
+        ids = (id(a), id(b))
+        wr = (weakref.ref(a), weakref.ref(b))
+        del a, b
+
+        # Nothing outside the cycle references either object now, so a full
+        # collection must reclaim both of them with the correct result: no
+        # false immortalization and no crash.
+        gc.collect()
+
+        self.assertIsNone(wr[0]())
+        self.assertIsNone(wr[1]())
+        # The reclaimed objects must not linger as (falsely immortalized)
+        # tracked objects.
+        live_ids = {id(o) for o in gc.get_objects()}
+        self.assertNotIn(ids[0], live_ids)
+        self.assertNotIn(ids[1], live_ids)
+
     def test_trashcan(self):
         class Ouch:
             n = 0

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-07-12-00-00.gh-issue-153202.Ob4Lc1.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-07-12-00-00.gh-issue-153202.Ob4Lc1.rst
@@ -1,0 +1,6 @@
+During cyclic garbage collection, the free-threaded build now counts each
+unreachable object's incoming references in a side table of ``Py_ssize_t``
+counters instead of temporarily repurposing the object's ``ob_ref_local``
+field. This removes the previous dependency on that field being wide enough to
+hold an arbitrary count, so a reference cycle with more than 255
+cross-references to a single object is now collected correctly.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-07-14-30-00.gh-issue-153202.Zt9KqP.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-07-14-30-00.gh-issue-153202.Zt9KqP.rst
@@ -1,0 +1,4 @@
+Shrink the ``ob_ref_local`` reference-count field in the free-threaded build's
+object header from 32 bits to 8 bits. Only a few bits of the per-object local
+reference count are ever needed, so narrowing the field reduces the object
+header's size requirements while leaving room for other header fields.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-07-16-00-00.gh-issue-153202.Kp7Rn2.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-07-16-00-00.gh-issue-153202.Kp7Rn2.rst
@@ -1,0 +1,6 @@
+Update the remaining consumers of the free-threaded object header's
+``ob_ref_local`` field to the new 8-bit (``uint8_t``) width and the immortal
+representation based on ``ob_ref_shared``. Reference-count increments made by
+an object's owning thread now spill the excess into the shared reference count
+once the narrow local count would overflow past ~256, rather than overflowing
+the field or immortalizing the object.

--- a/Modules/_testcapi/object.c
+++ b/Modules/_testcapi/object.c
@@ -241,6 +241,102 @@ test_py_set_immortal(PyObject *self, PyObject *unused)
 }
 
 static PyObject *
+test_refcount_spill(PyObject *self, PyObject *unused)
+{
+#ifdef Py_GIL_DISABLED
+    // gh-153202: when a plain increment would overflow ob_ref_local (a uint32),
+    // the excess must spill into ob_ref_shared instead of immortalizing the
+    // object. Drive at least two overflow-spill cycles on a single object and
+    // confirm it stays mortal with a correct refcount.
+    if (PyType_Ready(&MyType) < 0) {
+        return NULL;
+    }
+
+    PyObject *op = PyObject_New(PyObject, &MyType);
+    if (op == NULL) {
+        return NULL;
+    }
+    // Ensure the shared reference count is merged on deallocation.
+    PyUnstable_EnableTryIncRef(op);
+
+    for (int cycle = 0; cycle < 2; cycle++) {
+        // Force ob_ref_local to its maximum so that the next single Py_INCREF
+        // overflows it and must spill. Re-establish thread ownership and clear
+        // the shared count each cycle: a spill resets ob_ref_local to 1, so the
+        // balancing Py_DECREF below merges the local count away and drops
+        // ownership. Clearing the shared count keeps Py_INCREF's and Py_DECREF's
+        // global refcount bookkeeping balanced across the cycle.
+        op->ob_tid = _Py_ThreadId();
+        op->ob_ref_local = UINT32_MAX;
+        op->ob_ref_shared &= _Py_REF_SHARED_FLAG_MASK;
+        Py_ssize_t before = Py_REFCNT(op);
+
+        Py_INCREF(op);  // must spill, not immortalize
+
+        if (PyUnstable_IsImmortal(op)) {
+            PyErr_SetString(PyExc_AssertionError,
+                            "object immortalized on ob_ref_local overflow");
+            return NULL;
+        }
+        if (Py_REFCNT(op) != before + 1) {
+            PyErr_SetString(PyExc_AssertionError,
+                            "refcount incorrect after overflow spill");
+            return NULL;
+        }
+        if (op->ob_ref_local != 1) {
+            PyErr_SetString(PyExc_AssertionError,
+                            "ob_ref_local not reset by overflow spill");
+            return NULL;
+        }
+
+        // Balance the Py_INCREF above so the global refcount total is unchanged
+        // by this cycle (the crafted counts are far too large to fully drain).
+        Py_DECREF(op);
+    }
+
+    // Confirm the object still deallocates correctly once its (now small)
+    // reference count is decremented back to zero. Re-establish ownership since
+    // the final spill cycle merged the local count away.
+    MyObject_dealloc_called = 0;
+    op->ob_tid = _Py_ThreadId();
+    op->ob_ref_local = 1;
+    op->ob_ref_shared &= _Py_REF_SHARED_FLAG_MASK;  // count = 0, keep flags
+    Py_DECREF(op);
+    if (MyObject_dealloc_called != 1) {
+        PyErr_SetString(PyExc_AssertionError,
+                        "object failed to deallocate after spill cycles");
+        return NULL;
+    }
+
+    // Finally, confirm that a reference count which has genuinely spilled into
+    // the shared count deallocates exactly once when drained to zero, using
+    // small counts. Build a real refcount of 5 with Py_INCREF (keeping the
+    // global total balanced), then relocate 3 of it into the shared count to
+    // mirror a post-spill layout.
+    MyObject_dealloc_called = 0;
+    PyObject *op2 = PyObject_New(PyObject, &MyType);
+    if (op2 == NULL) {
+        return NULL;
+    }
+    for (int i = 0; i < 4; i++) {
+        Py_INCREF(op2);
+    }
+    // Refcount is 5 and owned; move 3 references into the shared count.
+    op2->ob_ref_local = 2;
+    op2->ob_ref_shared = _Py_REF_SHARED(3, _Py_REF_MAYBE_WEAKREF);
+    for (int i = 0; i < 5; i++) {
+        Py_DECREF(op2);
+    }
+    if (MyObject_dealloc_called != 1) {
+        PyErr_SetString(PyExc_AssertionError,
+                        "spilled shared count did not deallocate at zero");
+        return NULL;
+    }
+#endif  // Py_GIL_DISABLED
+    Py_RETURN_NONE;
+}
+
+static PyObject *
 _test_incref(PyObject *ob)
 {
     return Py_NewRef(ob);
@@ -591,6 +687,7 @@ static PyMethodDef test_methods[] = {
     {"pyobject_is_unique_temporary_new_object", pyobject_is_unique_temporary_new_object, METH_NOARGS},
     {"test_py_try_inc_ref", test_py_try_inc_ref, METH_NOARGS},
     {"test_py_set_immortal", test_py_set_immortal, METH_NOARGS},
+    {"test_refcount_spill", test_refcount_spill, METH_NOARGS},
     {"test_xincref_doesnt_leak",test_xincref_doesnt_leak,        METH_NOARGS},
     {"test_incref_doesnt_leak", test_incref_doesnt_leak,         METH_NOARGS},
     {"test_xdecref_doesnt_leak",test_xdecref_doesnt_leak,        METH_NOARGS},

--- a/Modules/_testcapi/object.c
+++ b/Modules/_testcapi/object.c
@@ -244,7 +244,7 @@ static PyObject *
 test_refcount_spill(PyObject *self, PyObject *unused)
 {
 #ifdef Py_GIL_DISABLED
-    // gh-153202: when a plain increment would overflow ob_ref_local (a uint32),
+    // gh-153202: when a plain increment would overflow ob_ref_local (a uint8_t),
     // the excess must spill into ob_ref_shared instead of immortalizing the
     // object. Drive at least two overflow-spill cycles on a single object and
     // confirm it stays mortal with a correct refcount.
@@ -267,7 +267,7 @@ test_refcount_spill(PyObject *self, PyObject *unused)
         // ownership. Clearing the shared count keeps Py_INCREF's and Py_DECREF's
         // global refcount bookkeeping balanced across the cycle.
         op->ob_tid = _Py_ThreadId();
-        op->ob_ref_local = UINT32_MAX;
+        op->ob_ref_local = UINT8_MAX;
         op->ob_ref_shared &= _Py_REF_SHARED_FLAG_MASK;
         Py_ssize_t before = Py_REFCNT(op);
 

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -433,6 +433,20 @@ _Py_DecRefShared(PyObject *o)
     _Py_DecRefSharedDebug(o, NULL, 0);
 }
 
+#ifdef Py_GIL_DISABLED
+// Validate the ob_ref_shared layout used to mark immortal objects (see
+// Include/refcount.h). The immortal count values must sit within the
+// representable shared count range, and the stored ob_ref_shared marker must
+// remain a positive Py_ssize_t so that a plain arithmetic-right-shift check can
+// distinguish immortal objects from ordinary ones with (bounded) large counts.
+static_assert(_Py_IMMORTAL_MINIMUM_SHARED_REFCNT > 0
+              && _Py_IMMORTAL_INITIAL_SHARED_REFCNT >= _Py_IMMORTAL_MINIMUM_SHARED_REFCNT
+              && _Py_IMMORTAL_INITIAL_SHARED_REFCNT <= _Py_REF_SHARED_COUNT_MAX,
+              "immortal shared refcount must fit in the ob_ref_shared count range");
+static_assert(_Py_REF_SHARED_IMMORTAL > 0,
+              "immortal ob_ref_shared marker must be a positive Py_ssize_t");
+#endif
+
 void
 _Py_MergeZeroLocalRefcount(PyObject *op)
 {
@@ -489,6 +503,9 @@ _Py_ExplicitMergeRefcount(PyObject *op, Py_ssize_t extra)
         new_shared = _Py_REF_SHARED(refcnt, _Py_REF_MERGED);
     } while (!_Py_atomic_compare_exchange_ssize(&op->ob_ref_shared,
                                                 &shared, new_shared));
+    // An ordinary object's merged count must never reach the reserved immortal
+    // range, otherwise it would be misidentified as immortal.
+    assert(refcnt < _Py_IMMORTAL_MINIMUM_SHARED_REFCNT);
     return refcnt;
 }
 
@@ -2779,8 +2796,8 @@ _Py_SetImmortalUntracked(PyObject *op)
     }
 #ifdef Py_GIL_DISABLED
     _Py_atomic_store_uintptr_relaxed(&op->ob_tid, _Py_UNOWNED_TID);
-    _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, _Py_IMMORTAL_REFCNT_LOCAL);
-    _Py_atomic_store_ssize_relaxed(&op->ob_ref_shared, 0);
+    _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, 0);
+    _Py_atomic_store_ssize_relaxed(&op->ob_ref_shared, _Py_REF_SHARED_IMMORTAL);
     _Py_atomic_or_uint8(&op->ob_gc_bits, _PyGC_BITS_DEFERRED);
 #elif SIZEOF_VOID_P > 4
     op->ob_flags = _Py_IMMORTAL_FLAGS;

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -445,6 +445,21 @@ static_assert(_Py_IMMORTAL_MINIMUM_SHARED_REFCNT > 0
               "immortal shared refcount must fit in the ob_ref_shared count range");
 static_assert(_Py_REF_SHARED_IMMORTAL > 0,
               "immortal ob_ref_shared marker must be a positive Py_ssize_t");
+// gh-153202: _Py_REF_DEFERRED (pycore_object.h) is added, alone, to the
+// shared count of every deferred-refcounted object (module dicts, functions,
+// code objects, ...) the instant deferred refcounting is enabled -- before
+// that object accrues a single real reference. If the immortal threshold
+// were ever at or below _Py_REF_DEFERRED, every such object would be
+// misreported as immortal from birth, corrupting GC/refcount handling for
+// it (this exact collision shipped once and crashed every _bootstrap_python
+// invocation via a lost GC-tracked bit on interp->builtins; see
+// bug-fix/gh-153202/fix-summary.md). Require a wide margin above
+// _Py_REF_DEFERRED, not just strict inequality, since a deferred object's
+// count legitimately fluctuates above that baseline as real references
+// come and go.
+static_assert(_Py_IMMORTAL_MINIMUM_SHARED_REFCNT
+              > _Py_REF_DEFERRED + (_Py_REF_SHARED_COUNT_MAX / 8),
+              "immortal threshold must stay well clear of _Py_REF_DEFERRED");
 #endif
 
 void

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -489,7 +489,7 @@ _Py_ExplicitMergeRefcount(PyObject *op, Py_ssize_t extra)
 
     // gh-119999: Write to ob_ref_local and ob_tid before merging the refcount.
     Py_ssize_t local = (Py_ssize_t)op->ob_ref_local;
-    _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, 0);
+    _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, 0);
     _Py_atomic_store_uintptr_relaxed(&op->ob_tid, 0);
 
     Py_ssize_t refcnt;
@@ -2757,7 +2757,7 @@ new_reference(PyObject *op)
 #ifdef _Py_THREAD_SANITIZER
     _Py_atomic_store_uintptr_relaxed(&op->ob_tid, _Py_ThreadId());
     _Py_atomic_store_uint8_relaxed(&op->ob_gc_bits, 0);
-    _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, 1);
+    _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, 1);
     _Py_atomic_store_ssize_relaxed(&op->ob_ref_shared, 0);
 #else
     op->ob_tid = _Py_ThreadId();
@@ -2796,7 +2796,7 @@ _Py_SetImmortalUntracked(PyObject *op)
     }
 #ifdef Py_GIL_DISABLED
     _Py_atomic_store_uintptr_relaxed(&op->ob_tid, _Py_UNOWNED_TID);
-    _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, 0);
+    _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, 0);
     _Py_atomic_store_ssize_relaxed(&op->ob_ref_shared, _Py_REF_SHARED_IMMORTAL);
     _Py_atomic_or_uint8(&op->ob_gc_bits, _PyGC_BITS_DEFERRED);
 #elif SIZEOF_VOID_P > 4

--- a/Python/ceval.h
+++ b/Python/ceval.h
@@ -113,9 +113,12 @@
 #define Py_DECREF(arg) \
     do { \
         PyObject *op = _PyObject_CAST(arg); \
+        /* gh-153202: see refcount.h's Py_DECREF -- load ob_ref_local */ \
+        /* unconditionally, in parallel with the ownership check, */ \
+        /* instead of gating it behind it. */ \
+        uint8_t local = _Py_atomic_load_uint8_relaxed(&op->ob_ref_local); \
         if (_Py_IsOwnedByCurrentThread(op)) { \
             _Py_DECREF_STAT_INC(); \
-            uint8_t local = _Py_atomic_load_uint8_relaxed(&op->ob_ref_local); \
             local--; \
             _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, local); \
             if (local == 0) { \

--- a/Python/ceval.h
+++ b/Python/ceval.h
@@ -115,9 +115,9 @@
         PyObject *op = _PyObject_CAST(arg); \
         if (_Py_IsOwnedByCurrentThread(op)) { \
             _Py_DECREF_STAT_INC(); \
-            uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local); \
+            uint8_t local = _Py_atomic_load_uint8_relaxed(&op->ob_ref_local); \
             local--; \
-            _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, local); \
+            _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, local); \
             if (local == 0) { \
                 _Py_MergeZeroLocalRefcount(op); \
             } \

--- a/Python/ceval.h
+++ b/Python/ceval.h
@@ -113,20 +113,20 @@
 #define Py_DECREF(arg) \
     do { \
         PyObject *op = _PyObject_CAST(arg); \
-        uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local); \
-        if (local == _Py_IMMORTAL_REFCNT_LOCAL) { \
-            _Py_DECREF_IMMORTAL_STAT_INC(); \
-            break; \
-        } \
-        _Py_DECREF_STAT_INC(); \
         if (_Py_IsOwnedByCurrentThread(op)) { \
+            _Py_DECREF_STAT_INC(); \
+            uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local); \
             local--; \
             _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, local); \
             if (local == 0) { \
                 _Py_MergeZeroLocalRefcount(op); \
             } \
         } \
+        else if (_Py_IsImmortal(op)) { \
+            _Py_DECREF_IMMORTAL_STAT_INC(); \
+        } \
         else { \
+            _Py_DECREF_STAT_INC(); \
             _Py_DecRefShared(op); \
         } \
     } while (0)

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -6,6 +6,7 @@
 #include "pycore_frame.h"         // FRAME_CLEARED
 #include "pycore_freelist.h"      // _PyObject_ClearFreeLists()
 #include "pycore_genobject.h"     // _PyGen_GetGeneratorFromFrame()
+#include "pycore_hashtable.h"     // _Py_hashtable_t
 #include "pycore_initconfig.h"    // _PyStatus_NO_MEMORY()
 #include "pycore_interp.h"        // PyInterpreterState.gc
 #include "pycore_interpframe.h"   // _PyFrame_GetLocalsArray()
@@ -1800,12 +1801,35 @@ show_stats_each_generations(GCState *gcstate)
     // TODO
 }
 
+// Fetch the incoming-reference scratch counter for `op` from the side table
+// used by handle_resurrected_objects(). Every object in the unreachable set is
+// pre-inserted into the table, so a missing entry indicates a programming
+// error.
+static inline Py_ssize_t
+gc_refs_get(_Py_hashtable_t *gc_refs, PyObject *op)
+{
+    _Py_hashtable_entry_t *entry = _Py_hashtable_get_entry(gc_refs, op);
+    assert(entry != NULL);
+    return (Py_ssize_t)(intptr_t)entry->value;
+}
+
+static inline void
+gc_refs_add(_Py_hashtable_t *gc_refs, PyObject *op, Py_ssize_t delta)
+{
+    _Py_hashtable_entry_t *entry = _Py_hashtable_get_entry(gc_refs, op);
+    assert(entry != NULL);
+    Py_ssize_t value = (Py_ssize_t)(intptr_t)entry->value;
+    entry->value = (void *)(intptr_t)(value + delta);
+}
+
 // Traversal callback for handle_resurrected_objects.
 static int
 visit_decref_unreachable(PyObject *op, void *data)
 {
     if (gc_is_unreachable(op) && _PyObject_GC_IS_TRACKED(op)) {
-        op->ob_ref_local -= 1;
+        // `data` is the side table mapping each unreachable object to its
+        // incoming-reference scratch counter (see handle_resurrected_objects).
+        gc_refs_add((_Py_hashtable_t *)data, op, -1);
     }
     return 0;
 }
@@ -1840,11 +1864,39 @@ _PyGC_VisitFrameStack(_PyInterpreterFrame *frame, visitproc visit, void *arg)
 static int
 handle_resurrected_objects(struct collection_state *state)
 {
-    // First, find externally reachable objects by computing the reference
-    // count difference in ob_ref_local. We can't use ob_tid here because
-    // that's already used to store the unreachable worklist.
+    // First, find externally reachable objects by computing, for each
+    // unreachable object, the number of references that come from *outside*
+    // the unreachable set.
+    //
+    // We can't store that count in the object itself: `ob_tid` already holds
+    // the unreachable worklist and `ob_ref_shared` holds the (merged) refcount
+    // we need to read. This code used to repurpose `ob_ref_local` as the
+    // scratch counter, but that field is being narrowed to 8 bits and can no
+    // longer hold an arbitrary incoming-reference count (a single cycle can
+    // have well over 255 cross-references to one object). Instead we use a side
+    // table keyed by object that stores a full `Py_ssize_t` per object, so the
+    // scratch counter can never overflow regardless of the cycle's size and no
+    // longer depends on the width of any object field.
     PyObject *op;
     struct worklist_iter iter;
+
+    _Py_hashtable_t *gc_refs = _Py_hashtable_new(
+        _Py_hashtable_hash_ptr, _Py_hashtable_compare_direct);
+    if (gc_refs == NULL) {
+        return -1;
+    }
+
+    // Pre-populate the side table with a zero counter for every unreachable
+    // object. Doing this up front means the later accumulation and traversal
+    // only ever update existing entries, so they never allocate and therefore
+    // can't fail partway through a tp_traverse call.
+    WORKSTACK_FOR_EACH(&state->unreachable, op) {
+        if (_Py_hashtable_set(gc_refs, op, (void *)(intptr_t)0) < 0) {
+            _Py_hashtable_destroy(gc_refs);
+            return -1;
+        }
+    }
+
     WORKSTACK_FOR_EACH_ITER(&state->unreachable, &iter, op) {
         assert(gc_is_unreachable(op));
         assert(_Py_REF_IS_MERGED(op->ob_ref_shared));
@@ -1859,42 +1911,37 @@ handle_resurrected_objects(struct collection_state *state)
         }
 
         Py_ssize_t refcount = (op->ob_ref_shared >> _Py_REF_SHARED_SHIFT);
-        if (refcount > INT32_MAX) {
-            // The refcount is too big to fit in `ob_ref_local`. Mark the
-            // object as immortal and bail out.
-            gc_clear_unreachable(op);
-            worklist_remove(&iter);
-            _Py_SetImmortal(op);
-            continue;
-        }
 
-        op->ob_ref_local += (uint32_t)refcount;
-
-        // Subtract one to account for the reference from the worklist.
-        op->ob_ref_local -= 1;
+        // Start from the full refcount, minus one for the reference held by
+        // the worklist. visit_decref_unreachable() then subtracts one for each
+        // reference that originates from another unreachable object, leaving
+        // the number of references from outside the unreachable set.
+        gc_refs_add(gc_refs, op, refcount - 1);
 
         traverseproc traverse = Py_TYPE(op)->tp_traverse;
-        (void)traverse(op, visit_decref_unreachable, NULL);
+        (void)traverse(op, visit_decref_unreachable, gc_refs);
     }
 
     // Find resurrected objects
     bool any_resurrected = false;
     WORKSTACK_FOR_EACH(&state->unreachable, op) {
-        int32_t gc_refs = (int32_t)op->ob_ref_local;
-        op->ob_ref_local = 0;  // restore ob_ref_local
+        Py_ssize_t gc_refs_count = gc_refs_get(gc_refs, op);
 
-        _PyObject_ASSERT(op, gc_refs >= 0);
+        _PyObject_ASSERT(op, gc_refs_count >= 0);
 
-        if (gc_is_unreachable(op) && gc_refs > 0) {
+        if (gc_is_unreachable(op) && gc_refs_count > 0) {
             // Clear the unreachable flag on any transitively reachable objects
             // from this one.
             any_resurrected = true;
             gc_clear_unreachable(op);
             if (mark_reachable(op) < 0) {
+                _Py_hashtable_destroy(gc_refs);
                 return -1;
             }
         }
     }
+
+    _Py_hashtable_destroy(gc_refs);
 
     if (any_resurrected) {
         // Remove resurrected objects from the unreachable list.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core refcounting, immortality, and free-threaded cyclic GC in every `Py_INCREF`/`Py_DECREF` path; incorrect spill or immortal thresholds could cause use-after-free, leaks, or missed collection.
> 
> **Overview**
> **Free-threaded object headers:** `ob_ref_local` is narrowed from 32 bits to **8 bits** (`uint8_t`). Immortality is no longer signaled through that field; static and runtime immortals use a reserved high count in **`ob_ref_shared`** (`_Py_REF_SHARED_IMMORTAL`), with compile-time checks so the threshold stays well above **`_Py_REF_DEFERRED`** (avoids falsely immortal deferred-refcounted objects).
> 
> **Reference counting:** Owner-thread `Py_INCREF` / `Py_DECREF`, `_Py_RefcntAdd`, and `_Py_TryIncrefFast` load `ob_ref_local` in parallel with the ownership check (gh-153202 perf). When the local count would exceed 255, excess is **spilled into `ob_ref_shared`** and local is reset to 1—objects are not immortalized on overflow. `_Py_IsImmortal`, `Py_REFCNT`, and `Py_SET_REFCNT` follow the new layout.
> 
> **Cyclic GC:** Incoming-reference scratch counts during resurrection handling use a **`Py_ssize_t` side hashtable** instead of reusing `ob_ref_local`, so cycles with 300+ cross-refs collect correctly.
> 
> Tests cover spill/dealloc, concurrent spill, large GC cycles, pinned `sizeof(PyObject)`, and updated immortality expectations; internal GC docs and NEWS entries document the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7368c97a33785d31ec0125776793627d36ce6f15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->