### PR TITLE
Gh 153202 full proposal

### DIFF
--- a/Include/cpython/pyatomic.h
+++ b/Include/cpython/pyatomic.h
@@ -524,6 +524,12 @@ static inline void
 _Py_atomic_store_ssize_release(Py_ssize_t *obj, Py_ssize_t value);
 
 static inline void
+_Py_atomic_store_int32_release(int32_t *obj, int32_t value);
+
+static inline int32_t
+_Py_atomic_load_int32_acquire(const int32_t *obj);
+
+static inline void
 _Py_atomic_store_int8_release(int8_t *obj, int8_t value);
 
 static inline void

--- a/Include/cpython/pyatomic_gcc.h
+++ b/Include/cpython/pyatomic_gcc.h
@@ -593,6 +593,10 @@ _Py_atomic_store_uint32_release(uint32_t *obj, uint32_t value)
 { __atomic_store_n(obj, value, __ATOMIC_RELEASE); }
 
 static inline void
+_Py_atomic_store_int32_release(int32_t *obj, int32_t value)
+{ __atomic_store_n(obj, value, __ATOMIC_RELEASE); }
+
+static inline void
 _Py_atomic_store_uint64_release(uint64_t *obj, uint64_t value)
 { __atomic_store_n(obj, value, __ATOMIC_RELEASE); }
 
@@ -602,6 +606,10 @@ _Py_atomic_load_uint64_acquire(const uint64_t *obj)
 
 static inline uint32_t
 _Py_atomic_load_uint32_acquire(const uint32_t *obj)
+{ return __atomic_load_n(obj, __ATOMIC_ACQUIRE); }
+
+static inline int32_t
+_Py_atomic_load_int32_acquire(const int32_t *obj)
 { return __atomic_load_n(obj, __ATOMIC_ACQUIRE); }
 
 static inline Py_ssize_t

--- a/Include/cpython/pyatomic_msc.h
+++ b/Include/cpython/pyatomic_msc.h
@@ -1125,6 +1125,19 @@ _Py_atomic_store_uint32_release(uint32_t *obj, uint32_t value)
 }
 
 static inline void
+_Py_atomic_store_int32_release(int32_t *obj, int32_t value)
+{
+#if defined(_M_X64) || defined(_M_IX86)
+    *(int32_t volatile *)obj = value;
+#elif defined(_M_ARM64)
+    _Py_atomic_ASSERT_ARG_TYPE(__int32);
+    __stlr32((unsigned __int32 volatile *)obj, (unsigned __int32)value);
+#else
+#  error "no implementation of _Py_atomic_store_int32_release"
+#endif
+}
+
+static inline void
 _Py_atomic_store_uint64_release(uint64_t *obj, uint64_t value)
 {
 #if defined(_M_X64) || defined(_M_IX86)
@@ -1159,6 +1172,18 @@ _Py_atomic_load_uint32_acquire(const uint32_t *obj)
     return (uint32_t)__ldar32((uint32_t volatile *)obj);
 #else
 #  error "no implementation of _Py_atomic_load_uint32_acquire"
+#endif
+}
+
+static inline int32_t
+_Py_atomic_load_int32_acquire(const int32_t *obj)
+{
+#if defined(_M_X64) || defined(_M_IX86)
+    return *(int32_t volatile *)obj;
+#elif defined(_M_ARM64)
+    return (int32_t)__ldar32((uint32_t volatile *)obj);
+#else
+#  error "no implementation of _Py_atomic_load_int32_acquire"
 #endif
 }
 

--- a/Include/cpython/pyatomic_std.h
+++ b/Include/cpython/pyatomic_std.h
@@ -1064,6 +1064,14 @@ _Py_atomic_store_uint32_release(uint32_t *obj, uint32_t value)
 }
 
 static inline void
+_Py_atomic_store_int32_release(int32_t *obj, int32_t value)
+{
+    _Py_USING_STD;
+    atomic_store_explicit((_Atomic(int32_t)*)obj, value,
+                          memory_order_release);
+}
+
+static inline void
 _Py_atomic_store_uint64_release(uint64_t *obj, uint64_t value)
 {
     _Py_USING_STD;
@@ -1084,6 +1092,14 @@ _Py_atomic_load_uint32_acquire(const uint32_t *obj)
 {
     _Py_USING_STD;
     return atomic_load_explicit((const _Atomic(uint32_t)*)obj,
+                                memory_order_acquire);
+}
+
+static inline int32_t
+_Py_atomic_load_int32_acquire(const int32_t *obj)
+{
+    _Py_USING_STD;
+    return atomic_load_explicit((const _Atomic(int32_t)*)obj,
                                 memory_order_acquire);
 }
 

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -23,9 +23,11 @@ extern "C" {
 // reference counting so that they are not immediately deallocated when the
 // non-deferred reference count drops to zero.
 //
-// The value is half the maximum shared refcount because the low two bits of
-// `ob_ref_shared` are used for flags.
-#define _Py_REF_DEFERRED (PY_SSIZE_T_MAX / 8)
+// The value is half the maximum shared refcount (gh-153202 full proposal:
+// derived from _Py_REF_SHARED_COUNT_MAX, which is now based on int32_t's
+// range rather than Py_ssize_t's, since ob_ref_shared was narrowed to
+// int32_t alongside ob_ref_local -- see Include/refcount.h).
+#define _Py_REF_DEFERRED (_Py_REF_SHARED_COUNT_MAX / 2)
 
 /* For backwards compatibility -- Do not use this */
 #define _Py_IsImmortalLoose(op) _Py_IsImmortal
@@ -74,7 +76,7 @@ PyAPI_FUNC(int) _PyObject_IsFreed(PyObject *);
 #if defined(Py_GIL_DISABLED)
 #define _PyObject_HEAD_INIT(type)                   \
     {                                               \
-        .ob_ref_local = _Py_IMMORTAL_REFCNT_LOCAL,  \
+        .ob_ref_shared = _Py_REF_SHARED_IMMORTAL,   \
         .ob_flags = _Py_STATICALLY_ALLOCATED_FLAG,  \
         .ob_gc_bits = _PyGC_BITS_DEFERRED,          \
         .ob_type = (type)                           \
@@ -153,19 +155,23 @@ static inline void _Py_RefcntAdd(PyObject* op, Py_ssize_t n)
 #  endif
 #else
     if (_Py_IsOwnedByCurrentThread(op)) {
-        uint32_t local = op->ob_ref_local;
+        uint8_t local = op->ob_ref_local;
         Py_ssize_t refcnt = (Py_ssize_t)local + n;
-#  if PY_SSIZE_T_MAX > UINT32_MAX
-        if (refcnt > (Py_ssize_t)UINT32_MAX) {
-            // Make the object immortal if the 32-bit local reference count
-            // would overflow.
-            refcnt = _Py_IMMORTAL_REFCNT_LOCAL;
+        if (refcnt > (Py_ssize_t)UINT8_MAX) {
+            // The narrow (uint8_t) local reference count would overflow: spill
+            // the excess into the shared reference count rather than overflowing
+            // the field or immortalizing the object.
+            _Py_atomic_add_int32(&op->ob_ref_shared,
+                                 _Py_STATIC_CAST(int32_t, (refcnt - 1) << _Py_REF_SHARED_SHIFT));
+            _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, 1);
         }
-#  endif
-        _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, (uint32_t)refcnt);
+        else {
+            _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, (uint8_t)refcnt);
+        }
     }
     else {
-        _Py_atomic_add_ssize(&op->ob_ref_shared, (n << _Py_REF_SHARED_SHIFT));
+        _Py_atomic_add_int32(&op->ob_ref_shared,
+                              _Py_STATIC_CAST(int32_t, n << _Py_REF_SHARED_SHIFT));
     }
 #  ifdef Py_REF_DEBUG
     _Py_AddRefTotal(_PyThreadState_GET(), n);
@@ -190,8 +196,8 @@ _PyObject_IsUniquelyReferenced(PyObject *ob)
     // ensure that other threads cannot concurrently create new references to
     // this object.
     return (_Py_IsOwnedByCurrentThread(ob) &&
-            _Py_atomic_load_uint32_relaxed(&ob->ob_ref_local) == 1 &&
-            _Py_atomic_load_ssize_relaxed(&ob->ob_ref_shared) == 0);
+            _Py_atomic_load_uint8_relaxed(&ob->ob_ref_local) == 1 &&
+            _Py_atomic_load_int32_relaxed(&ob->ob_ref_shared) == 0);
 #endif
 }
 
@@ -261,7 +267,7 @@ _Py_DECREF_SPECIALIZED(PyObject *op, const destructor destruct)
 }
 
 static inline int
-_Py_REF_IS_MERGED(Py_ssize_t ob_ref_shared)
+_Py_REF_IS_MERGED(int32_t ob_ref_shared)
 {
     return (ob_ref_shared & _Py_REF_SHARED_FLAG_MASK) == _Py_REF_MERGED;
 }
@@ -520,19 +526,32 @@ _PyObject_InitVar(PyVarObject *op, PyTypeObject *typeobj, Py_ssize_t size)
  */
 static inline int
 _Py_TryIncrefFast(PyObject *op) {
-    uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local);
-    local += 1;
-    if (local == 0) {
-        // immortal
-        _Py_INCREF_IMMORTAL_STAT_INC();
-        return 1;
-    }
+    // gh-153202: see refcount.h's Py_INCREF -- load ob_ref_local
+    // unconditionally, in parallel with the ownership check, instead of
+    // gating it behind it.
+    uint8_t local = _Py_atomic_load_uint8_relaxed(&op->ob_ref_local);
     if (_Py_IsOwnedByCurrentThread(op)) {
+        if (local == UINT8_MAX) {
+            // ob_ref_local (a uint8_t) would overflow: spill the accumulated
+            // local count into the shared reference count rather than
+            // overflowing the field or immortalizing the object.
+            _Py_atomic_add_int32(&op->ob_ref_shared,
+                _Py_STATIC_CAST(int32_t, local) << _Py_REF_SHARED_SHIFT);
+            _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, 1);
+        }
+        else {
+            _Py_atomic_store_uint8_relaxed(&op->ob_ref_local,
+                _Py_STATIC_CAST(uint8_t, local + 1));
+        }
         _Py_INCREF_STAT_INC();
-        _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, local);
 #ifdef Py_REF_DEBUG
         _Py_IncRefTotal(_PyThreadState_GET());
 #endif
+        return 1;
+    }
+    if (_Py_IsImmortal(op)) {
+        // immortal
+        _Py_INCREF_IMMORTAL_STAT_INC();
         return 1;
     }
     return 0;
@@ -541,7 +560,7 @@ _Py_TryIncrefFast(PyObject *op) {
 static inline int
 _Py_TryIncRefShared(PyObject *op)
 {
-    Py_ssize_t shared = _Py_atomic_load_ssize_relaxed(&op->ob_ref_shared);
+    int32_t shared = _Py_atomic_load_int32_relaxed(&op->ob_ref_shared);
     for (;;) {
         // If the shared refcount is zero and the object is either merged
         // or may not have weak references, then we cannot incref it.
@@ -549,7 +568,7 @@ _Py_TryIncRefShared(PyObject *op)
             return 0;
         }
 
-        if (_Py_atomic_compare_exchange_ssize(
+        if (_Py_atomic_compare_exchange_int32(
                 &op->ob_ref_shared,
                 &shared,
                 shared + (1 << _Py_REF_SHARED_SHIFT))) {
@@ -624,12 +643,12 @@ _Py_NewRefWithLock(PyObject *op)
 #endif
     _Py_INCREF_STAT_INC();
     for (;;) {
-        Py_ssize_t shared = _Py_atomic_load_ssize_relaxed(&op->ob_ref_shared);
-        Py_ssize_t new_shared = shared + (1 << _Py_REF_SHARED_SHIFT);
+        int32_t shared = _Py_atomic_load_int32_relaxed(&op->ob_ref_shared);
+        int32_t new_shared = shared + (1 << _Py_REF_SHARED_SHIFT);
         if ((shared & _Py_REF_SHARED_FLAG_MASK) == 0) {
             new_shared |= _Py_REF_MAYBE_WEAKREF;
         }
-        if (_Py_atomic_compare_exchange_ssize(
+        if (_Py_atomic_compare_exchange_int32(
                 &op->ob_ref_shared,
                 &shared,
                 new_shared)) {
@@ -654,12 +673,12 @@ _PyObject_SetMaybeWeakref(PyObject *op)
         return;
     }
     for (;;) {
-        Py_ssize_t shared = _Py_atomic_load_ssize_relaxed(&op->ob_ref_shared);
+        int32_t shared = _Py_atomic_load_int32_relaxed(&op->ob_ref_shared);
         if ((shared & _Py_REF_SHARED_FLAG_MASK) != 0) {
             // Nothing to do if it's in WEAKREFS, QUEUED, or MERGED states.
             return;
         }
-        if (_Py_atomic_compare_exchange_ssize(
+        if (_Py_atomic_compare_exchange_int32(
                 &op->ob_ref_shared, &shared, shared | _Py_REF_MAYBE_WEAKREF)) {
             return;
         }
@@ -680,8 +699,8 @@ _PyObject_ResurrectStart(PyObject *op)
 #endif
 #ifdef Py_GIL_DISABLED
     _Py_atomic_store_uintptr_relaxed(&op->ob_tid, _Py_ThreadId());
-    _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, 1);
-    _Py_atomic_store_ssize_relaxed(&op->ob_ref_shared, 0);
+    _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, 1);
+    _Py_atomic_store_int32_relaxed(&op->ob_ref_shared, 0);
 #else
     Py_SET_REFCNT(op, 1);
 #endif
@@ -709,11 +728,11 @@ _PyObject_ResurrectEnd(PyObject *op)
     }
     return 1;
 #else
-    uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local);
-    Py_ssize_t shared = _Py_atomic_load_ssize_acquire(&op->ob_ref_shared);
+    uint8_t local = _Py_atomic_load_uint8_relaxed(&op->ob_ref_local);
+    int32_t shared = _Py_atomic_load_int32_acquire(&op->ob_ref_shared);
     if (_Py_IsOwnedByCurrentThread(op) && local == 1 && shared == 0) {
         // Fast-path: object has a single refcount and is owned by this thread
-        _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, 0);
+        _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, 0);
 # ifdef Py_TRACE_REFS
         _Py_ForgetReference(op);
 # endif

--- a/Include/internal/pycore_weakref.h
+++ b/Include/internal/pycore_weakref.h
@@ -62,7 +62,7 @@ static inline int _is_dead(PyObject *obj)
     // be able to "see" the target object even though it is supposed to be
     // unreachable.  See issue gh-60806.
 #if defined(Py_GIL_DISABLED)
-    Py_ssize_t shared = _Py_atomic_load_ssize_relaxed(&obj->ob_ref_shared);
+    int32_t shared = _Py_atomic_load_int32_relaxed(&obj->ob_ref_shared);
     return shared == _Py_REF_SHARED(0, _Py_REF_MERGED);
 #else
     return (Py_REFCNT(obj) == 0);

--- a/Include/object.h
+++ b/Include/object.h
@@ -81,7 +81,8 @@ whose size is determined when the object is allocated.
         _Py_STATICALLY_ALLOCATED_FLAG, \
         { 0 },                      \
         0,                          \
-        _Py_IMMORTAL_REFCNT_LOCAL,  \
+        0,                          \
+        _Py_REF_SHARED_IMMORTAL,    \
         0,                          \
         (type),                     \
     },
@@ -161,8 +162,34 @@ struct _object {
     uint16_t ob_flags;
     PyMutex ob_mutex;           // per-object lock
     uint8_t ob_gc_bits;         // gc-related state
-    uint32_t ob_ref_local;      // local reference count
-    Py_ssize_t ob_ref_shared;   // shared (atomic) reference count
+    uint8_t ob_ref_local;       // local reference count (only a few bits used)
+    // ob_ref_shared can be transiently *negative* (see Python/brc.c) when a
+    // non-owning thread decrefs an object before the owning thread has
+    // merged in its own local count, so this must stay a signed type -- an
+    // unsigned type would turn that legitimate negative state into a huge
+    // wraparound value and corrupt every comparison against it (including
+    // the immortal-threshold checks below). int32_t (gh-153202 full
+    // proposal, following markshannon's suggestion on the issue) preserves
+    // that sign correctly while still halving this field from Py_ssize_t.
+    int32_t ob_ref_shared;      // shared (atomic) reference count
+    // gh-153202 experiment: scratch space for the cyclic GC's incoming-
+    // reference count during stop-the-world collection (see
+    // handle_resurrected_objects() in Python/gc_free_threading.c), replacing
+    // a _Py_hashtable_t side table keyed by object. Meaningless outside of a
+    // collection pass; every object that reaches it is unconditionally
+    // written before being read, so it needs no initialization at object
+    // creation.
+    uint32_t gc_scratch;
+    // ob_type is deliberately placed after ob_ref_shared/gc_scratch rather
+    // than before: the two adjacent 4-byte fields above pack into the same
+    // alignment gap ob_ref_shared alone used to leave before the 8-byte-
+    // aligned tail, so sizeof(PyObject) stays 32 bytes -- confirmed by an
+    // offsetof/sizeof measurement, and pinned by
+    // test_capi.test_object.PyObjectSizeTest. This is what makes narrowing
+    // ob_ref_local (task 1) genuinely memory-neutral: on its own it saves
+    // nothing (the freed bytes are absorbed as padding regardless of
+    // reordering), but paired with also narrowing ob_ref_shared here, the
+    // freed space is enough to add gc_scratch for free instead.
     PyTypeObject *ob_type;
 };
 #endif // !defined(_Py_OPAQUE_PYOBJECT)

--- a/Include/refcount.h
+++ b/Include/refcount.h
@@ -68,13 +68,6 @@ check by comparing the reference count field to the minimum immortality refcount
 #define _Py_STATIC_IMMORTAL_MINIMUM_REFCNT ((Py_ssize_t)(6L << 28))
 #endif
 
-// Py_GIL_DISABLED builds indicate immortal objects using `ob_ref_local`, which is
-// always 32-bits.
-#ifdef Py_GIL_DISABLED
-#define _Py_IMMORTAL_REFCNT_LOCAL UINT32_MAX
-#endif
-
-
 #ifdef Py_GIL_DISABLED
    // The shared reference count uses the two least-significant bits to store
    // flags. The remaining bits are used to store the reference count.
@@ -90,6 +83,52 @@ check by comparing the reference count field to the minimum immortality refcount
    // Create a shared field from a refcnt and desired flags
 #  define _Py_REF_SHARED(refcnt, flags) \
               (((refcnt) << _Py_REF_SHARED_SHIFT) + (flags))
+
+   // The maximum value representable in the *count* portion of ob_ref_shared
+   // (the bits above the two flags). ob_ref_shared is a signed int32_t (see
+   // Include/object.h -- it can legitimately go negative, so this must stay
+   // signed), so the count occupies the remaining high bits of that 32-bit
+   // range, not Py_ssize_t's 64-bit range (gh-153202 full proposal: this used
+   // to be Py_ssize_t before ob_ref_shared was also narrowed to int32_t
+   // alongside ob_ref_local).
+#  define _Py_REF_SHARED_COUNT_MAX \
+              (_Py_STATIC_CAST(Py_ssize_t, INT32_MAX >> _Py_REF_SHARED_SHIFT))
+
+   // Immortal objects are marked by a reserved, very large value in the count
+   // portion of ob_ref_shared, mirroring the saturation/immortality scheme the
+   // default (with-GIL) build uses for ob_refcnt. Keeping the immortal marker
+   // on ob_ref_shared makes immortality independent of ob_ref_local's width.
+   //
+   // An object is immortal when its shared count is at least
+   // _Py_IMMORTAL_MINIMUM_SHARED_REFCNT. Newly immortalized objects are given
+   // _Py_IMMORTAL_INITIAL_SHARED_REFCNT (higher than the minimum), so that a
+   // huge number of increfs/decrefs can occur before immortality could be lost.
+   //
+   // The immortal region is placed in the top quarter of the count range
+   // rather than at its midpoint: pycore_object.h's _Py_REF_DEFERRED (the
+   // baseline every deferred-refcounted object's shared count is initialized
+   // to) is defined as half of _Py_REF_SHARED_COUNT_MAX, i.e. almost exactly
+   // the midpoint of this range. A midpoint immortal threshold made every
+   // freshly deferred-refcounted object (module dicts, functions, code
+   // objects, ...) immortal from the moment deferred refcounting was
+   // enabled, with zero real references (gh-153202 fix-summary, "已知限制").
+   // Starting the immortal region a full COUNT_MAX/4 above _Py_REF_DEFERRED
+   // leaves headroom no realistic number of increfs/decrefs could cross; see
+   // the static_assert against _Py_REF_DEFERRED in Objects/object.c. That
+   // headroom shrinks a lot now that COUNT_MAX fits in int32_t instead of
+   // Py_ssize_t (~2**29 instead of ~2**59) -- still astronomically more than
+   // any real object's reference count, but a much tighter margin than
+   // before, worth keeping in mind if this range is ever narrowed further.
+#  define _Py_IMMORTAL_MINIMUM_SHARED_REFCNT \
+              (_Py_REF_SHARED_COUNT_MAX - (_Py_REF_SHARED_COUNT_MAX / 4))
+#  define _Py_IMMORTAL_INITIAL_SHARED_REFCNT \
+              (_Py_IMMORTAL_MINIMUM_SHARED_REFCNT + \
+               ((_Py_REF_SHARED_COUNT_MAX - _Py_IMMORTAL_MINIMUM_SHARED_REFCNT) / 2))
+
+   // The ob_ref_shared value used to represent a freshly immortal object (both
+   // statically allocated and runtime-promoted). The two flag bits are clear.
+#  define _Py_REF_SHARED_IMMORTAL \
+              _Py_REF_SHARED(_Py_IMMORTAL_INITIAL_SHARED_REFCNT, _Py_REF_SHARED_INIT)
 #endif  // Py_GIL_DISABLED
 #endif  // _Py_OPAQUE_PYOBJECT
 
@@ -106,13 +145,14 @@ PyAPI_FUNC(Py_ssize_t) Py_REFCNT(PyObject *ob);
     #if !defined(Py_GIL_DISABLED)
         return ob->ob_refcnt;
     #else
-        uint32_t local = _Py_atomic_load_uint32_relaxed(&ob->ob_ref_local);
-        if (local == _Py_IMMORTAL_REFCNT_LOCAL) {
+        int32_t shared = _Py_atomic_load_int32_relaxed(&ob->ob_ref_shared);
+        Py_ssize_t shared_count =
+            Py_ARITHMETIC_RIGHT_SHIFT(int32_t, shared, _Py_REF_SHARED_SHIFT);
+        if (shared_count >= _Py_IMMORTAL_MINIMUM_SHARED_REFCNT) {
             return _Py_IMMORTAL_INITIAL_REFCNT;
         }
-        Py_ssize_t shared = _Py_atomic_load_ssize_relaxed(&ob->ob_ref_shared);
-        return _Py_STATIC_CAST(Py_ssize_t, local) +
-               Py_ARITHMETIC_RIGHT_SHIFT(Py_ssize_t, shared, _Py_REF_SHARED_SHIFT);
+        uint8_t local = _Py_atomic_load_uint8_relaxed(&ob->ob_ref_local);
+        return _Py_STATIC_CAST(Py_ssize_t, local) + shared_count;
     #endif
     }
     #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
@@ -126,8 +166,9 @@ PyAPI_FUNC(Py_ssize_t) Py_REFCNT(PyObject *ob);
 static inline Py_ALWAYS_INLINE int _Py_IsImmortal(PyObject *op)
 {
 #if defined(Py_GIL_DISABLED)
-    return (_Py_atomic_load_uint32_relaxed(&op->ob_ref_local) ==
-            _Py_IMMORTAL_REFCNT_LOCAL);
+    int32_t shared = _Py_atomic_load_int32_relaxed(&op->ob_ref_shared);
+    return Py_ARITHMETIC_RIGHT_SHIFT(int32_t, shared, _Py_REF_SHARED_SHIFT)
+           >= _Py_IMMORTAL_MINIMUM_SHARED_REFCNT;
 #elif SIZEOF_VOID_P > 4
     return _Py_CAST(int32_t, op->ob_refcnt) < 0;
 #else
@@ -173,23 +214,16 @@ static inline void Py_SET_REFCNT(PyObject *ob, Py_ssize_t refcnt) {
     ob->ob_refcnt = refcnt;
 #endif
 #else
-    if (_Py_IsOwnedByCurrentThread(ob)) {
-        if ((size_t)refcnt > (size_t)UINT32_MAX) {
-            // On overflow, make the object immortal
-            ob->ob_tid = _Py_UNOWNED_TID;
-            ob->ob_ref_local = _Py_IMMORTAL_REFCNT_LOCAL;
-            ob->ob_ref_shared = 0;
-        }
-        else {
-            // Set local refcount to desired refcount and shared refcount
-            // to zero, but preserve the shared refcount flags.
-            ob->ob_ref_local = _Py_STATIC_CAST(uint32_t, refcnt);
-            ob->ob_ref_shared &= _Py_REF_SHARED_FLAG_MASK;
-        }
+    if (_Py_IsOwnedByCurrentThread(ob) && (size_t)refcnt <= (size_t)UINT8_MAX) {
+        // Set local refcount to desired refcount and shared refcount
+        // to zero, but preserve the shared refcount flags.
+        ob->ob_ref_local = _Py_STATIC_CAST(uint8_t, refcnt);
+        ob->ob_ref_shared &= _Py_REF_SHARED_FLAG_MASK;
     }
     else {
         // Set local refcount to zero and shared refcount to desired refcount.
-        // Mark the object as merged.
+        // Mark the object as merged. A refcount that does not fit in the narrow
+        // local count is also stored here rather than immortalizing the object.
         ob->ob_tid = _Py_UNOWNED_TID;
         ob->ob_ref_local = 0;
         ob->ob_ref_shared = _Py_REF_SHARED(refcnt, _Py_REF_MERGED);
@@ -269,18 +303,34 @@ static inline Py_ALWAYS_INLINE void Py_INCREF(PyObject *op)
     // Non-limited C API and limited C API for Python 3.9 and older access
     // directly PyObject.ob_refcnt.
 #if defined(Py_GIL_DISABLED)
-    uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local);
-    uint32_t new_local = local + 1;
-    if (new_local == 0) {
+    // gh-153202: load the local count unconditionally, in parallel with the
+    // ownership check below -- ob_ref_local and ob_tid are independent
+    // fields, so gating this load behind the ownership branch would
+    // serialize what can otherwise be two independent loads into one
+    // dependency chain, in every Py_INCREF call in the interpreter (see
+    // fix-summary.md 9.6 for the pyperformance evidence).
+    uint8_t local = _Py_atomic_load_uint8_relaxed(&op->ob_ref_local);
+    if (_Py_IsOwnedByCurrentThread(op)) {
+        if (local == UINT8_MAX) {
+            // ob_ref_local (a uint8_t) would overflow: spill the accumulated
+            // local count into the shared reference count rather than
+            // overflowing the field or immortalizing the object (immortality
+            // must not depend on ob_ref_local's width).
+            _Py_atomic_add_int32(&op->ob_ref_shared,
+                _Py_STATIC_CAST(int32_t, local) << _Py_REF_SHARED_SHIFT);
+            _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, 1);
+        }
+        else {
+            _Py_atomic_store_uint8_relaxed(&op->ob_ref_local,
+                _Py_STATIC_CAST(uint8_t, local + 1));
+        }
+    }
+    else if (_Py_IsImmortal(op)) {
         _Py_INCREF_IMMORTAL_STAT_INC();
-        // local is equal to _Py_IMMORTAL_REFCNT_LOCAL: do nothing
         return;
     }
-    if (_Py_IsOwnedByCurrentThread(op)) {
-        _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, new_local);
-    }
     else {
-        _Py_atomic_add_ssize(&op->ob_ref_shared, (1 << _Py_REF_SHARED_SHIFT));
+        _Py_atomic_add_int32(&op->ob_ref_shared, (1 << _Py_REF_SHARED_SHIFT));
     }
 #elif SIZEOF_VOID_P > 4
     uint32_t cur_refcnt = op->ob_refcnt;
@@ -342,24 +392,27 @@ static inline void Py_DECREF(PyObject *op) {
 #elif defined(Py_GIL_DISABLED) && defined(Py_REF_DEBUG)
 static inline void Py_DECREF(const char *filename, int lineno, PyObject *op)
 {
-    uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local);
-    if (local == _Py_IMMORTAL_REFCNT_LOCAL) {
-        _Py_DECREF_IMMORTAL_STAT_INC();
-        return;
-    }
-    _Py_DECREF_STAT_INC();
-    _Py_DECREF_DecRefTotal();
+    // gh-153202: see Py_INCREF -- load ob_ref_local unconditionally, in
+    // parallel with the ownership check, instead of gating it behind it.
+    uint8_t local = _Py_atomic_load_uint8_relaxed(&op->ob_ref_local);
     if (_Py_IsOwnedByCurrentThread(op)) {
         if (local == 0) {
             _Py_NegativeRefcount(filename, lineno, op);
         }
+        _Py_DECREF_STAT_INC();
+        _Py_DECREF_DecRefTotal();
         local--;
-        _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, local);
+        _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, local);
         if (local == 0) {
             _Py_MergeZeroLocalRefcount(op);
         }
     }
+    else if (_Py_IsImmortal(op)) {
+        _Py_DECREF_IMMORTAL_STAT_INC();
+    }
     else {
+        _Py_DECREF_STAT_INC();
+        _Py_DECREF_DecRefTotal();
         _Py_DecRefSharedDebug(op, filename, lineno);
     }
 }
@@ -368,20 +421,22 @@ static inline void Py_DECREF(const char *filename, int lineno, PyObject *op)
 #elif defined(Py_GIL_DISABLED)
 static inline void Py_DECREF(PyObject *op)
 {
-    uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local);
-    if (local == _Py_IMMORTAL_REFCNT_LOCAL) {
-        _Py_DECREF_IMMORTAL_STAT_INC();
-        return;
-    }
-    _Py_DECREF_STAT_INC();
+    // gh-153202: see Py_INCREF -- load ob_ref_local unconditionally, in
+    // parallel with the ownership check, instead of gating it behind it.
+    uint8_t local = _Py_atomic_load_uint8_relaxed(&op->ob_ref_local);
     if (_Py_IsOwnedByCurrentThread(op)) {
+        _Py_DECREF_STAT_INC();
         local--;
-        _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, local);
+        _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, local);
         if (local == 0) {
             _Py_MergeZeroLocalRefcount(op);
         }
     }
+    else if (_Py_IsImmortal(op)) {
+        _Py_DECREF_IMMORTAL_STAT_INC();
+    }
     else {
+        _Py_DECREF_STAT_INC();
         _Py_DecRefShared(op);
     }
 }

--- a/InternalDocs/garbage_collector.md
+++ b/InternalDocs/garbage_collector.md
@@ -136,28 +136,52 @@ and, during garbage collection, differentiate reachable vs. unreachable objects.
     object -----> +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+ \
                   |                     ob_tid                    | |
                   +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+ |
-                  | pad | ob_mutex | ob_gc_bits |  ob_ref_local   | |
-                  +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+ | PyObject_HEAD
-                  |                  ob_ref_shared                | |
+                  | pad | ob_mutex | ob_gc_bits |  ob_ref_local   | | PyObject_HEAD
+                  +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+ |
+                  |      ob_ref_shared     |      gc_scratch      | |
                   +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+ |
                   |                    *ob_type                   | |
                   +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+ /
                   |                      ...                      |
 ```
 
-Note that not all fields are to scale. `pad` is two bytes, `ob_mutex` and
-`ob_gc_bits` are each one byte, and `ob_ref_local` is four bytes. The
-other fields, `ob_tid`, `ob_ref_shared`, and `ob_type`, are all
-pointer-sized (that is, eight bytes on a 64-bit platform).
+Note that not all fields are to scale. `pad` is two bytes, and `ob_mutex`,
+`ob_gc_bits`, and `ob_ref_local` are each one byte (only a few bits of
+`ob_ref_local` are ever used). `ob_ref_shared` and `gc_scratch` are each four
+bytes (`ob_ref_shared` is a signed `int32_t`, not pointer-sized -- see
+below). `ob_tid` and `ob_type` are pointer-sized (that is, eight bytes on a
+64-bit platform).
 
 
 The garbage collector also temporarily repurposes the `ob_tid` (thread ID)
-and `ob_ref_local` (local reference count) fields for other purposes during
-collections.  The `ob_tid` field is later restored from the containing
-mimalloc segment data structure.  In some cases, such as when the original
-allocating thread exits, this can result in a different `ob_tid` value.
-Code should not rely on `ob_tid` being stable across operations that may
-trigger garbage collection.
+field during collections, using it as a linked-list pointer for the worklist
+of objects being processed.  The `ob_tid` field is later restored from the
+containing mimalloc segment data structure.  In some cases, such as when the
+original allocating thread exits, this can result in a different `ob_tid`
+value.  Code should not rely on `ob_tid` being stable across operations that
+may trigger garbage collection.
+
+To determine which unreachable objects are still reachable from outside the
+unreachable set, the collector counts each object's incoming references in
+the `gc_scratch` field (gh-153202 experiment). Earlier versions of this
+narrowing repurposed `ob_ref_local` for this scratch count directly, but that
+field is too narrow (a single cycle can have well over 255 cross-references
+to one object); a later version used a temporary `_Py_hashtable_t` side table
+of `Py_ssize_t` counters keyed by object instead, avoiding any dependency on
+object field widths but adding hashtable-operation overhead to every
+collection pass with unreachable objects. `gc_scratch` trades some of that
+width-independence (it is `uint32_t`, not `Py_ssize_t`) to avoid the
+hashtable.
+
+This full-proposal variant also narrows `ob_ref_shared` itself from
+`Py_ssize_t` down to a signed `int32_t` (signed, not the `uint32_t` first
+suggested, because `Python/brc.c`'s biased reference counting scheme
+requires `ob_ref_shared` to be able to go transiently negative), and
+reorders the struct so `ob_type` comes after both `ob_ref_shared` and
+`gc_scratch` instead of before. That combination makes `gc_scratch` free:
+the two adjacent four-byte fields fill exactly the alignment gap that
+`ob_ref_shared` alone used to leave before the eight-byte-aligned `ob_type`,
+so `sizeof(PyObject)` is unchanged from before `gc_scratch` was added.
 
 
 C APIs

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1024,7 +1024,17 @@ def expected_failure_if_gil_disabled():
     return lambda test_case: test_case
 
 if Py_GIL_DISABLED:
-    _header = 'PHBBInP'
+    # gh-153202 full proposal: struct _object gained a gc_scratch field
+    # (uint32_t, replacing a GC side table) at no net size cost, by also
+    # narrowing ob_ref_shared from Py_ssize_t to int32_t (signed -- see
+    # Python/brc.c) and reordering fields so ob_type comes last -- see the
+    # longer explanation in test_capi/test_object.py's PyObjectSizeTest.
+    # This mirrors the real field types exactly, so unlike the earlier
+    # gc_scratch-only layout it needs no trailing padding: P(ob_tid)
+    # H(ob_flags) B(ob_mutex) B(ob_gc_bits) B(ob_ref_local) i(ob_ref_shared)
+    # I(gc_scratch) P(ob_type) already ends on the struct's own 8-byte
+    # alignment boundary.
+    _header = 'PHBBBiIP'
 else:
     _header = 'nP'
 _align = '0n'

--- a/Lib/test/test_bigmem.py
+++ b/Lib/test/test_bigmem.py
@@ -1263,6 +1263,21 @@ class ImmortalityTest(unittest.TestCase):
     def test_stickiness(self, size):
         """Check that immortality is "sticky", so that
            once an object is immortal it remains so."""
+        # On the default build an object is permanently immortalized once its
+        # reference count crosses the immortality threshold (~2**31), so this
+        # test drives o1's refcount past that point (hence the 2**31 sizing)
+        # and checks that it stays immortal.
+        #
+        # The free-threaded build does NOT immortalize objects on
+        # reference-count overflow: the narrow (uint8_t) ob_ref_local spills
+        # its excess into ob_ref_shared instead, so there is no reference count
+        # reachable in practice that makes an ordinary object immortal here.
+        # (This 2**31 sizing used to coincide with the free-threaded
+        # local-overflow point only because that point was formerly ~2**32;
+        # that coincidence no longer exists.)
+        if support.Py_GIL_DISABLED:
+            self.skipTest("the free-threaded build does not immortalize "
+                          "objects on reference-count overflow")
         _testcapi = import_helper.import_module('_testcapi')
         if size < _2G:
             # Not enough memory to cause immortality on overflow

--- a/Lib/test/test_capi/test_immortal.py
+++ b/Lib/test/test_capi/test_immortal.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 from test.support import import_helper
 
@@ -20,6 +21,22 @@ class TestUnstableCAPI(unittest.TestCase):
                 self.assertFalse(_testcapi.is_immortal(non_immortal))
 
         # CRASHES _testcapi.is_immortal(NULL)
+
+    def test_ordinary_object_not_immortal_after_many_increfs(self):
+        # gh-153202: the free-threaded immortal marker no longer lives in
+        # ob_ref_local (whose width is being reduced), so an ordinary object
+        # whose reference count is incremented well past 250 from a single
+        # thread must not be misreported as immortal.
+        obj = object()
+        # Build many references from this single thread. This drives the
+        # owning-thread incref fast path far above 250 references.
+        refs = [obj] * 300
+        try:
+            self.assertGreaterEqual(sys.getrefcount(obj), 250)
+            self.assertFalse(_testcapi.is_immortal(obj))
+        finally:
+            del refs
+        self.assertFalse(_testcapi.is_immortal(obj))
 
 
 class TestInternalCAPI(unittest.TestCase):

--- a/Lib/test/test_capi/test_object.py
+++ b/Lib/test/test_capi/test_object.py
@@ -1,6 +1,7 @@
 import enum
 import os
 import pickle
+import struct
 import sys
 import textwrap
 import unittest
@@ -224,6 +225,18 @@ class IsUniquelyReferencedTest(unittest.TestCase):
         self.assertFalse(_testcapi.is_uniquely_referenced(42))
         # CRASHES is_uniquely_referenced(NULL)
 
+@unittest.skipUnless(support.Py_GIL_DISABLED, 'requires free-threaded build')
+class RefcountSpillTest(unittest.TestCase):
+    """gh-153202: ob_ref_local overflow must spill into ob_ref_shared rather
+    than immortalizing the object."""
+    def test_refcount_spill(self):
+        # Drives at least two overflow-spill cycles on one object and confirms
+        # it stays mortal, keeps a correct refcount, and deallocates when its
+        # reference count (including the spilled shared count) reaches zero.
+        # The C helper raises AssertionError on any failure.
+        _testcapi.test_refcount_spill()
+
+
 class CAPITest(unittest.TestCase):
     def check_negative_refcount(self, code):
         # bpo-35059: Check that Py_DECREF() reports the correct filename
@@ -340,6 +353,65 @@ class CAPITest(unittest.TestCase):
         # test NULL object
         output = self.pyobject_dump(NULL)
         self.assertRegex(output, r'<object at .* is freed>')
+
+
+@support.cpython_only
+class PyObjectSizeTest(unittest.TestCase):
+    # sizeof(PyObject) is exported to out-of-process debuggers and remote
+    # profilers (PEP 768) through several surfaces that all derive from the
+    # same C expression:
+    #   * _Py_DebugOffsets.pyobject.size  (Include/internal/pycore_debug_offsets.h)
+    #   * _testinternalcapi.SIZEOF_PYOBJECT (Modules/_testinternalcapi.c)
+    #   * SIZEOF_PYOBJECT in Modules/_remote_debugging/_remote_debugging.h
+    # A width change to a PyObject header field (e.g. ob_ref_local /
+    # ob_ref_shared in the free-threaded build) therefore silently changes the
+    # exported size with no signal to tooling that cached the old layout.  Pin
+    # the value so such a change trips this test and forces a conscious update
+    # plus a decision about bumping _Py_DebugOffsets.version.
+
+    def test_sizeof_pyobject_matches_base_object(self):
+        # The exported diagnostic must track the real object layout.  The base
+        # ``object`` type stores nothing beyond a PyObject, so its basic size
+        # is exactly sizeof(PyObject); if the two ever disagree, the exported
+        # debug-offsets data has drifted from reality.
+        self.assertEqual(_testinternalcapi.SIZEOF_PYOBJECT,
+                         object.__basicsize__)
+
+    def test_sizeof_pyobject_pinned(self):
+        # Independently recompute sizeof(PyObject) from the documented header
+        # layout (Include/object.h).  Changing a field width forces this
+        # expectation to be updated in lockstep, which is the point.
+        pointer = struct.calcsize('P')
+        if support.Py_GIL_DISABLED:
+            # struct _object (free-threaded build, gh-153202 full proposal):
+            #   uintptr_t     ob_tid          (P)
+            #   uint16_t      ob_flags        (H)
+            #   PyMutex       ob_mutex        (B)
+            #   uint8_t       ob_gc_bits      (B)
+            #   uint8_t       ob_ref_local    (B)
+            #   int32_t       ob_ref_shared   (i)
+            #   uint32_t      gc_scratch      (I)
+            #   PyTypeObject *ob_type         (P)
+            # gc_scratch (replacing a _Py_hashtable_t GC side table -- see
+            # handle_resurrected_objects() in Python/gc_free_threading.c) is
+            # memory-neutral here: narrowing ob_ref_shared from Py_ssize_t to
+            # int32_t (signed, because Python/brc.c requires it to be able to
+            # go transiently negative -- not the literal uint32_t originally
+            # suggested on the issue) frees exactly the bytes gc_scratch
+            # needs, and placing ob_type *after* both narrow fields instead of
+            # before lets them share the alignment gap ob_ref_shared alone
+            # used to leave before the 8-byte-aligned tail. Net size is
+            # unchanged from the pre-experiment 32-byte layout. Unlike a real
+            # C compiler, struct.calcsize() aligns each field but does not
+            # round the total up to the struct's largest member alignment; no
+            # explicit trailing padding is needed here only because the
+            # struct happens to already end on an 8-byte boundary (P is last).
+            expected = struct.calcsize('PHBBBiIP')
+        else:
+            # struct _object (default build): a pointer-sized refcount union
+            # followed by the ob_type pointer.
+            expected = 2 * pointer
+        self.assertEqual(_testinternalcapi.SIZEOF_PYOBJECT, expected)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_free_threading/test_refcount.py
+++ b/Lib/test/test_free_threading/test_refcount.py
@@ -1,0 +1,98 @@
+import sys
+import threading
+import unittest
+
+from test.support import import_helper, threading_helper
+
+
+_testcapi = import_helper.import_module("_testcapi")
+
+
+@threading_helper.requires_working_threading()
+class TestRefcountOverflowSpill(unittest.TestCase):
+    def test_concurrent_incref_overflow_spill(self):
+        # gh-153202: In the free-threaded build ``ob_ref_local`` is a uint8_t,
+        # so it can only hold a small (< 256) local reference count.  When the
+        # owning thread increments an object's reference count past that
+        # ~256-entry boundary, the excess must "spill" into the shared
+        # reference count -- it must never overflow the field or immortalize
+        # the object.
+        #
+        # Drive one object's reference count far past the boundary from the
+        # owning thread (exercising the overflow-spill path many times) while
+        # several other threads concurrently create and drop references through
+        # the shared reference count, then confirm the final reference count is
+        # exactly correct and the object was not immortalized.
+        #
+        # The reference-count assertions are only made once every worker thread
+        # has been joined, so the object's state is quiescent and the expected
+        # count is deterministic (this makes the test robust against re-runs;
+        # it is intended to pass with no flakiness across many consecutive
+        # runs, e.g. ``-F --forever``).
+
+        class C:
+            pass
+
+        # ``obj`` is created here, so it is owned by the thread running this
+        # test.  Only *this* thread's increfs use the narrow local count and
+        # can trigger the overflow-spill path, so the owner workload below must
+        # run on this thread rather than in a spawned worker.
+        obj = C()
+
+        NUM_WORKERS = 8
+        # Comfortably larger than the 256-entry local boundary so the owning
+        # thread crosses it (and spills) many times.
+        NUM_REFS = 5000
+
+        # References held permanently by the owning thread for the duration of
+        # the measurement.  Building these drives the owner-thread local count
+        # far past 256, forcing repeated spills into the shared count.
+        owner_refs = []
+
+        # Synchronize the owner and all workers so the spill path and the
+        # shared-count increfs genuinely race.
+        barrier = threading.Barrier(NUM_WORKERS + 1)
+
+        def worker():
+            # A non-owning thread: each incref goes through the atomic shared
+            # reference count.  Every reference taken here is dropped again, so
+            # once the thread is joined it has contributed a net zero to the
+            # reference count.
+            barrier.wait()
+            held = []
+            for _ in range(NUM_REFS):
+                held.append(obj)
+            del held
+
+        threads = [threading.Thread(target=worker) for _ in range(NUM_WORKERS)]
+        for thread in threads:
+            thread.start()
+
+        # Baseline includes the local ``obj`` name plus the temporary reference
+        # created for the ``sys.getrefcount`` argument.
+        base = sys.getrefcount(obj)
+
+        barrier.wait()
+        for _ in range(NUM_REFS):
+            owner_refs.append(obj)
+
+        for thread in threads:
+            thread.join()
+
+        # Every worker has been joined, so their references are gone and only
+        # the owner's ``NUM_REFS`` references (plus the baseline) remain.
+        self.assertEqual(sys.getrefcount(obj), base + NUM_REFS)
+
+        # The overflow must have spilled into the shared count, not
+        # immortalized the object.
+        self.assertFalse(_testcapi.is_immortal(obj))
+
+        # Dropping the owner's references brings the count back to the baseline,
+        # confirming the spilled shared count is accounted for on decref.
+        owner_refs.clear()
+        self.assertEqual(sys.getrefcount(obj), base)
+        self.assertFalse(_testcapi.is_immortal(obj))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -433,6 +433,44 @@ class GCTests(unittest.TestCase):
         self.assertEqual((e, f), (0, 1))
         self.assertEqual((h, i), (0, 0))
 
+    def test_collect_cycle_with_many_cross_references(self):
+        # gh-153202: During cyclic collection the free-threaded GC computes,
+        # for each unreachable object, the number of references coming from
+        # outside the unreachable set. That scratch counter must be able to
+        # hold an arbitrary count; if it were bounded (e.g. to an 8-bit field)
+        # a cycle with more than 255 references to a single object would
+        # overflow it and cause the object to be falsely treated as still
+        # reachable (or crash). Build such a cycle between just two objects and
+        # confirm it is collected.
+        N = 300  # comfortably more than 255
+
+        class Node:
+            pass
+
+        a = Node()
+        b = Node()
+        # Reference a <-> b N times each, forming one cycle with far more than
+        # 255 cross-references between the two objects.
+        a.refs = [b] * N
+        b.refs = [a] * N
+
+        ids = (id(a), id(b))
+        wr = (weakref.ref(a), weakref.ref(b))
+        del a, b
+
+        # Nothing outside the cycle references either object now, so a full
+        # collection must reclaim both of them with the correct result: no
+        # false immortalization and no crash.
+        gc.collect()
+
+        self.assertIsNone(wr[0]())
+        self.assertIsNone(wr[1]())
+        # The reclaimed objects must not linger as (falsely immortalized)
+        # tracked objects.
+        live_ids = {id(o) for o in gc.get_objects()}
+        self.assertNotIn(ids[0], live_ids)
+        self.assertNotIn(ids[1], live_ids)
+
     def test_trashcan(self):
         class Ouch:
             n = 0

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-11-00-00-00.gh-issue-153202.Xf3Wq9.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-11-00-00-00.gh-issue-153202.Xf3Wq9.rst
@@ -1,0 +1,9 @@
+In the free-threaded build, shrink the object header's ``ob_ref_local``
+field from 32 bits to 8 bits and ``ob_ref_shared`` from a pointer-sized
+field to 32 bits, adding a ``gc_scratch`` field used by the cyclic garbage
+collector to count each unreachable object's incoming references during
+collection (replacing a hash table previously used for the same purpose)
+with no net change to the object header's size. Reference-count
+increments made by an object's owning thread spill the excess into the
+shared reference count once the narrow local count would overflow past
+~256, rather than overflowing the field or immortalizing the object.

--- a/Modules/_testcapi/object.c
+++ b/Modules/_testcapi/object.c
@@ -241,6 +241,102 @@ test_py_set_immortal(PyObject *self, PyObject *unused)
 }
 
 static PyObject *
+test_refcount_spill(PyObject *self, PyObject *unused)
+{
+#ifdef Py_GIL_DISABLED
+    // gh-153202: when a plain increment would overflow ob_ref_local (a uint8_t),
+    // the excess must spill into ob_ref_shared instead of immortalizing the
+    // object. Drive at least two overflow-spill cycles on a single object and
+    // confirm it stays mortal with a correct refcount.
+    if (PyType_Ready(&MyType) < 0) {
+        return NULL;
+    }
+
+    PyObject *op = PyObject_New(PyObject, &MyType);
+    if (op == NULL) {
+        return NULL;
+    }
+    // Ensure the shared reference count is merged on deallocation.
+    PyUnstable_EnableTryIncRef(op);
+
+    for (int cycle = 0; cycle < 2; cycle++) {
+        // Force ob_ref_local to its maximum so that the next single Py_INCREF
+        // overflows it and must spill. Re-establish thread ownership and clear
+        // the shared count each cycle: a spill resets ob_ref_local to 1, so the
+        // balancing Py_DECREF below merges the local count away and drops
+        // ownership. Clearing the shared count keeps Py_INCREF's and Py_DECREF's
+        // global refcount bookkeeping balanced across the cycle.
+        op->ob_tid = _Py_ThreadId();
+        op->ob_ref_local = UINT8_MAX;
+        op->ob_ref_shared &= _Py_REF_SHARED_FLAG_MASK;
+        Py_ssize_t before = Py_REFCNT(op);
+
+        Py_INCREF(op);  // must spill, not immortalize
+
+        if (PyUnstable_IsImmortal(op)) {
+            PyErr_SetString(PyExc_AssertionError,
+                            "object immortalized on ob_ref_local overflow");
+            return NULL;
+        }
+        if (Py_REFCNT(op) != before + 1) {
+            PyErr_SetString(PyExc_AssertionError,
+                            "refcount incorrect after overflow spill");
+            return NULL;
+        }
+        if (op->ob_ref_local != 1) {
+            PyErr_SetString(PyExc_AssertionError,
+                            "ob_ref_local not reset by overflow spill");
+            return NULL;
+        }
+
+        // Balance the Py_INCREF above so the global refcount total is unchanged
+        // by this cycle (the crafted counts are far too large to fully drain).
+        Py_DECREF(op);
+    }
+
+    // Confirm the object still deallocates correctly once its (now small)
+    // reference count is decremented back to zero. Re-establish ownership since
+    // the final spill cycle merged the local count away.
+    MyObject_dealloc_called = 0;
+    op->ob_tid = _Py_ThreadId();
+    op->ob_ref_local = 1;
+    op->ob_ref_shared &= _Py_REF_SHARED_FLAG_MASK;  // count = 0, keep flags
+    Py_DECREF(op);
+    if (MyObject_dealloc_called != 1) {
+        PyErr_SetString(PyExc_AssertionError,
+                        "object failed to deallocate after spill cycles");
+        return NULL;
+    }
+
+    // Finally, confirm that a reference count which has genuinely spilled into
+    // the shared count deallocates exactly once when drained to zero, using
+    // small counts. Build a real refcount of 5 with Py_INCREF (keeping the
+    // global total balanced), then relocate 3 of it into the shared count to
+    // mirror a post-spill layout.
+    MyObject_dealloc_called = 0;
+    PyObject *op2 = PyObject_New(PyObject, &MyType);
+    if (op2 == NULL) {
+        return NULL;
+    }
+    for (int i = 0; i < 4; i++) {
+        Py_INCREF(op2);
+    }
+    // Refcount is 5 and owned; move 3 references into the shared count.
+    op2->ob_ref_local = 2;
+    op2->ob_ref_shared = _Py_REF_SHARED(3, _Py_REF_MAYBE_WEAKREF);
+    for (int i = 0; i < 5; i++) {
+        Py_DECREF(op2);
+    }
+    if (MyObject_dealloc_called != 1) {
+        PyErr_SetString(PyExc_AssertionError,
+                        "spilled shared count did not deallocate at zero");
+        return NULL;
+    }
+#endif  // Py_GIL_DISABLED
+    Py_RETURN_NONE;
+}
+
+static PyObject *
 _test_incref(PyObject *ob)
 {
     return Py_NewRef(ob);
@@ -591,6 +687,7 @@ static PyMethodDef test_methods[] = {
     {"pyobject_is_unique_temporary_new_object", pyobject_is_unique_temporary_new_object, METH_NOARGS},
     {"test_py_try_inc_ref", test_py_try_inc_ref, METH_NOARGS},
     {"test_py_set_immortal", test_py_set_immortal, METH_NOARGS},
+    {"test_refcount_spill", test_refcount_spill, METH_NOARGS},
     {"test_xincref_doesnt_leak",test_xincref_doesnt_leak,        METH_NOARGS},
     {"test_incref_doesnt_leak", test_incref_doesnt_leak,         METH_NOARGS},
     {"test_xdecref_doesnt_leak",test_xdecref_doesnt_leak,        METH_NOARGS},

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -378,8 +378,8 @@ _Py_DecRefSharedIsDead(PyObject *o, const char *filename, int lineno)
     // Should we queue the object for the owning thread to merge?
     int should_queue;
 
-    Py_ssize_t new_shared;
-    Py_ssize_t shared = _Py_atomic_load_ssize_relaxed(&o->ob_ref_shared);
+    int32_t new_shared;
+    int32_t shared = _Py_atomic_load_int32_relaxed(&o->ob_ref_shared);
     do {
         should_queue = (shared == 0 || shared == _Py_REF_MAYBE_WEAKREF);
 
@@ -403,7 +403,7 @@ _Py_DecRefSharedIsDead(PyObject *o, const char *filename, int lineno)
             _Py_NegativeRefcount(filename, lineno, o);
         }
 #endif
-    } while (!_Py_atomic_compare_exchange_ssize(&o->ob_ref_shared,
+    } while (!_Py_atomic_compare_exchange_int32(&o->ob_ref_shared,
                                                 &shared, new_shared));
 
     if (should_queue) {
@@ -433,12 +433,41 @@ _Py_DecRefShared(PyObject *o)
     _Py_DecRefSharedDebug(o, NULL, 0);
 }
 
+#ifdef Py_GIL_DISABLED
+// Validate the ob_ref_shared layout used to mark immortal objects (see
+// Include/refcount.h). The immortal count values must sit within the
+// representable shared count range, and the stored ob_ref_shared marker must
+// remain a positive int32_t so that a plain arithmetic-right-shift check can
+// distinguish immortal objects from ordinary ones with (bounded) large counts.
+static_assert(_Py_IMMORTAL_MINIMUM_SHARED_REFCNT > 0
+              && _Py_IMMORTAL_INITIAL_SHARED_REFCNT >= _Py_IMMORTAL_MINIMUM_SHARED_REFCNT
+              && _Py_IMMORTAL_INITIAL_SHARED_REFCNT <= _Py_REF_SHARED_COUNT_MAX,
+              "immortal shared refcount must fit in the ob_ref_shared count range");
+static_assert(_Py_REF_SHARED_IMMORTAL > 0,
+              "immortal ob_ref_shared marker must be a positive int32_t");
+// gh-153202: _Py_REF_DEFERRED (pycore_object.h) is added, alone, to the
+// shared count of every deferred-refcounted object (module dicts, functions,
+// code objects, ...) the instant deferred refcounting is enabled -- before
+// that object accrues a single real reference. If the immortal threshold
+// were ever at or below _Py_REF_DEFERRED, every such object would be
+// misreported as immortal from birth, corrupting GC/refcount handling for
+// it (this exact collision shipped once and crashed every _bootstrap_python
+// invocation via a lost GC-tracked bit on interp->builtins; see
+// bug-fix/gh-153202/fix-summary.md). Require a wide margin above
+// _Py_REF_DEFERRED, not just strict inequality, since a deferred object's
+// count legitimately fluctuates above that baseline as real references
+// come and go.
+static_assert(_Py_IMMORTAL_MINIMUM_SHARED_REFCNT
+              > _Py_REF_DEFERRED + (_Py_REF_SHARED_COUNT_MAX / 8),
+              "immortal threshold must stay well clear of _Py_REF_DEFERRED");
+#endif
+
 void
 _Py_MergeZeroLocalRefcount(PyObject *op)
 {
     assert(op->ob_ref_local == 0);
 
-    Py_ssize_t shared = _Py_atomic_load_ssize_acquire(&op->ob_ref_shared);
+    int32_t shared = _Py_atomic_load_int32_acquire(&op->ob_ref_shared);
     if (shared == 0) {
         // Fast-path: shared refcount is zero (including flags)
         _Py_Dealloc(op);
@@ -451,10 +480,10 @@ _Py_MergeZeroLocalRefcount(PyObject *op)
     _Py_atomic_store_uintptr_relaxed(&op->ob_tid, 0);
 
     // Slow-path: atomically set the flags (low two bits) to _Py_REF_MERGED.
-    Py_ssize_t new_shared;
+    int32_t new_shared;
     do {
         new_shared = (shared & ~_Py_REF_SHARED_FLAG_MASK) | _Py_REF_MERGED;
-    } while (!_Py_atomic_compare_exchange_ssize(&op->ob_ref_shared,
+    } while (!_Py_atomic_compare_exchange_int32(&op->ob_ref_shared,
                                                 &shared, new_shared));
 
     if (new_shared == _Py_REF_MERGED) {
@@ -475,20 +504,23 @@ _Py_ExplicitMergeRefcount(PyObject *op, Py_ssize_t extra)
 
     // gh-119999: Write to ob_ref_local and ob_tid before merging the refcount.
     Py_ssize_t local = (Py_ssize_t)op->ob_ref_local;
-    _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, 0);
+    _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, 0);
     _Py_atomic_store_uintptr_relaxed(&op->ob_tid, 0);
 
     Py_ssize_t refcnt;
-    Py_ssize_t new_shared;
-    Py_ssize_t shared = _Py_atomic_load_ssize_relaxed(&op->ob_ref_shared);
+    int32_t new_shared;
+    int32_t shared = _Py_atomic_load_int32_relaxed(&op->ob_ref_shared);
     do {
-        refcnt = Py_ARITHMETIC_RIGHT_SHIFT(Py_ssize_t, shared, _Py_REF_SHARED_SHIFT);
+        refcnt = Py_ARITHMETIC_RIGHT_SHIFT(int32_t, shared, _Py_REF_SHARED_SHIFT);
         refcnt += local;
         refcnt += extra;
 
-        new_shared = _Py_REF_SHARED(refcnt, _Py_REF_MERGED);
-    } while (!_Py_atomic_compare_exchange_ssize(&op->ob_ref_shared,
+        new_shared = _Py_STATIC_CAST(int32_t, _Py_REF_SHARED(refcnt, _Py_REF_MERGED));
+    } while (!_Py_atomic_compare_exchange_int32(&op->ob_ref_shared,
                                                 &shared, new_shared));
+    // An ordinary object's merged count must never reach the reserved immortal
+    // range, otherwise it would be misidentified as immortal.
+    assert(refcnt < _Py_IMMORTAL_MINIMUM_SHARED_REFCNT);
     return refcnt;
 }
 
@@ -2740,8 +2772,8 @@ new_reference(PyObject *op)
 #ifdef _Py_THREAD_SANITIZER
     _Py_atomic_store_uintptr_relaxed(&op->ob_tid, _Py_ThreadId());
     _Py_atomic_store_uint8_relaxed(&op->ob_gc_bits, 0);
-    _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, 1);
-    _Py_atomic_store_ssize_relaxed(&op->ob_ref_shared, 0);
+    _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, 1);
+    _Py_atomic_store_int32_relaxed(&op->ob_ref_shared, 0);
 #else
     op->ob_tid = _Py_ThreadId();
     op->ob_gc_bits = 0;
@@ -2779,8 +2811,8 @@ _Py_SetImmortalUntracked(PyObject *op)
     }
 #ifdef Py_GIL_DISABLED
     _Py_atomic_store_uintptr_relaxed(&op->ob_tid, _Py_UNOWNED_TID);
-    _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, _Py_IMMORTAL_REFCNT_LOCAL);
-    _Py_atomic_store_ssize_relaxed(&op->ob_ref_shared, 0);
+    _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, 0);
+    _Py_atomic_store_int32_relaxed(&op->ob_ref_shared, _Py_REF_SHARED_IMMORTAL);
     _Py_atomic_or_uint8(&op->ob_gc_bits, _PyGC_BITS_DEFERRED);
 #elif SIZEOF_VOID_P > 4
     op->ob_flags = _Py_IMMORTAL_FLAGS;
@@ -2840,7 +2872,8 @@ PyUnstable_Object_EnableDeferredRefcount(PyObject *op)
         // Someone beat us to it!
         return 0;
     }
-    _Py_atomic_add_ssize(&op->ob_ref_shared, _Py_REF_SHARED(_Py_REF_DEFERRED, 0));
+    _Py_atomic_add_int32(&op->ob_ref_shared,
+                          _Py_STATIC_CAST(int32_t, _Py_REF_SHARED(_Py_REF_DEFERRED, 0)));
     return 1;
 #else
     return 0;
@@ -3208,7 +3241,7 @@ _PyTrash_thread_destroy_chain(PyThreadState *tstate)
 #ifdef Py_GIL_DISABLED
         uintptr_t tagged_ptr = op->ob_tid;
         op->ob_tid = 0;
-        _Py_atomic_store_ssize_relaxed(&op->ob_ref_shared, _Py_REF_MERGED);
+        _Py_atomic_store_int32_relaxed(&op->ob_ref_shared, _Py_REF_MERGED);
 #else
         uintptr_t tagged_ptr = _Py_AS_GC(op)->_gc_next;
         _Py_AS_GC(op)->_gc_next = 0;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14220,7 +14220,7 @@ can_immortalize_safely(PyObject *s)
     if (_Py_IsOwnedByCurrentThread(s) || _Py_IsImmortal(s)) {
         return true;
     }
-    Py_ssize_t shared = _Py_atomic_load_ssize(&s->ob_ref_shared);
+    int32_t shared = _Py_atomic_load_int32(&s->ob_ref_shared);
     return _Py_REF_IS_MERGED(shared);
 }
 #endif

--- a/Python/ceval.h
+++ b/Python/ceval.h
@@ -113,20 +113,23 @@
 #define Py_DECREF(arg) \
     do { \
         PyObject *op = _PyObject_CAST(arg); \
-        uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local); \
-        if (local == _Py_IMMORTAL_REFCNT_LOCAL) { \
-            _Py_DECREF_IMMORTAL_STAT_INC(); \
-            break; \
-        } \
-        _Py_DECREF_STAT_INC(); \
+        /* gh-153202: see refcount.h's Py_DECREF -- load ob_ref_local */ \
+        /* unconditionally, in parallel with the ownership check, */ \
+        /* instead of gating it behind it. */ \
+        uint8_t local = _Py_atomic_load_uint8_relaxed(&op->ob_ref_local); \
         if (_Py_IsOwnedByCurrentThread(op)) { \
+            _Py_DECREF_STAT_INC(); \
             local--; \
-            _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, local); \
+            _Py_atomic_store_uint8_relaxed(&op->ob_ref_local, local); \
             if (local == 0) { \
                 _Py_MergeZeroLocalRefcount(op); \
             } \
         } \
+        else if (_Py_IsImmortal(op)) { \
+            _Py_DECREF_IMMORTAL_STAT_INC(); \
+        } \
         else { \
+            _Py_DECREF_STAT_INC(); \
             _Py_DecRefShared(op); \
         } \
     } while (0)

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -240,7 +240,7 @@ merge_refcount(PyObject *op, Py_ssize_t extra)
     // No atomics necessary; all other threads in this interpreter are paused.
     op->ob_tid = 0;
     op->ob_ref_local = 0;
-    op->ob_ref_shared = _Py_REF_SHARED(refcount, _Py_REF_MERGED);
+    op->ob_ref_shared = _Py_STATIC_CAST(int32_t, _Py_REF_SHARED(refcount, _Py_REF_MERGED));
     return refcount;
 }
 
@@ -1805,7 +1805,7 @@ static int
 visit_decref_unreachable(PyObject *op, void *data)
 {
     if (gc_is_unreachable(op) && _PyObject_GC_IS_TRACKED(op)) {
-        op->ob_ref_local -= 1;
+        op->gc_scratch--;
     }
     return 0;
 }
@@ -1840,11 +1840,42 @@ _PyGC_VisitFrameStack(_PyInterpreterFrame *frame, visitproc visit, void *arg)
 static int
 handle_resurrected_objects(struct collection_state *state)
 {
-    // First, find externally reachable objects by computing the reference
-    // count difference in ob_ref_local. We can't use ob_tid here because
-    // that's already used to store the unreachable worklist.
+    // First, find externally reachable objects by computing, for each
+    // unreachable object, the number of references that come from *outside*
+    // the unreachable set.
+    //
+    // We can't store that count in `ob_ref_local` (narrowed to 8 bits, can't
+    // hold an arbitrary count -- a single cycle can have well over 255
+    // cross-references to one object) or in `ob_tid`/`ob_ref_shared` (already
+    // holding the unreachable worklist and the merged refcount). Instead this
+    // uses a dedicated `gc_scratch` field on the object (gh-153202 experiment,
+    // suggested by markshannon on the issue, replacing an earlier
+    // `_Py_hashtable_t` side table keyed by object -- see the issue thread for
+    // the performance rationale). This is the "full proposal" variant: unlike
+    // the earlier gc_scratch-only experiment, `ob_ref_shared` here has also
+    // been narrowed (to `int32_t`, not the literal `uint32_t` Mark suggested,
+    // because Python/brc.c's biased-refcounting scheme requires it to be able
+    // to go transiently negative), and the struct fields were reordered so
+    // that adding `gc_scratch` costs zero extra header bytes -- see
+    // Include/object.h.
     PyObject *op;
     struct worklist_iter iter;
+
+    // First pass: drop finalizer-untracked objects from the unreachable set,
+    // and set every remaining object's scratch counter to its own external-
+    // reference baseline (refcount minus the worklist's own reference).
+    //
+    // This must fully complete, for every object, before any decrements
+    // happen in the second pass below. gc_scratch is unsigned; the signed
+    // Py_ssize_t accumulator this replaced could go temporarily negative
+    // when a decrement (from another unreachable object's traversal, which
+    // can run before or after this object's own baseline is written,
+    // depending on worklist order) arrived before the baseline did. An
+    // unsigned counter can't represent that same temporary negative
+    // excursion -- it would wrap to a huge value instead -- so instead this
+    // splits the work into two passes: every baseline is written first, and
+    // only then does anything ever subtract from it, which never needs to
+    // go negative in a correct (non-buggy) traversal.
     WORKSTACK_FOR_EACH_ITER(&state->unreachable, &iter, op) {
         assert(gc_is_unreachable(op));
         assert(_Py_REF_IS_MERGED(op->ob_ref_shared));
@@ -1858,21 +1889,35 @@ handle_resurrected_objects(struct collection_state *state)
             continue;
         }
 
-        Py_ssize_t refcount = (op->ob_ref_shared >> _Py_REF_SHARED_SHIFT);
-        if (refcount > INT32_MAX) {
-            // The refcount is too big to fit in `ob_ref_local`. Mark the
-            // object as immortal and bail out.
-            gc_clear_unreachable(op);
-            worklist_remove(&iter);
-            _Py_SetImmortal(op);
-            continue;
-        }
+        Py_ssize_t refcount = Py_ARITHMETIC_RIGHT_SHIFT(int32_t,
+            op->ob_ref_shared, _Py_REF_SHARED_SHIFT);
 
-        op->ob_ref_local += (uint32_t)refcount;
+        // refcount can still exceed UINT32_MAX in principle here: deferred-
+        // refcounted objects (module dicts, functions, code objects, type
+        // objects, ...) carry the _Py_REF_DEFERRED baseline in their shared
+        // count from the moment deferred refcounting is enabled, regardless
+        // of how many real references they have. With ob_ref_shared narrowed
+        // to int32_t, that baseline (_Py_REF_SHARED_COUNT_MAX / 2, ~2**28)
+        // is now comfortably inside uint32_t's range on its own, so this
+        // saturation is no longer load-bearing the way it was when
+        // ob_ref_shared was still Py_ssize_t-wide -- but it's kept anyway as
+        // a cheap, always-correct safety net: gc_scratch is only ever
+        // compared against zero below, so any value that would overflow
+        // uint32_t is equally valid as UINT32_MAX (definitely more than the
+        // worklist's own reference, so definitely externally reachable),
+        // whereas a raw narrowing cast could wrap around to an arbitrary,
+        // possibly small or zero, value and silently misreport the object as
+        // unreachable garbage.
+        Py_ssize_t external_refs = refcount - 1;
+        op->gc_scratch = (external_refs > UINT32_MAX)
+            ? UINT32_MAX : (uint32_t)external_refs;
+    }
 
-        // Subtract one to account for the reference from the worklist.
-        op->ob_ref_local -= 1;
-
+    // Second pass: every remaining unreachable object's baseline is now set,
+    // so it's safe to subtract one from each target for every reference that
+    // originates from another unreachable object, leaving each object's
+    // count of references from *outside* the unreachable set.
+    WORKSTACK_FOR_EACH(&state->unreachable, op) {
         traverseproc traverse = Py_TYPE(op)->tp_traverse;
         (void)traverse(op, visit_decref_unreachable, NULL);
     }
@@ -1880,12 +1925,9 @@ handle_resurrected_objects(struct collection_state *state)
     // Find resurrected objects
     bool any_resurrected = false;
     WORKSTACK_FOR_EACH(&state->unreachable, op) {
-        int32_t gc_refs = (int32_t)op->ob_ref_local;
-        op->ob_ref_local = 0;  // restore ob_ref_local
+        uint32_t gc_refs_count = op->gc_scratch;
 
-        _PyObject_ASSERT(op, gc_refs >= 0);
-
-        if (gc_is_unreachable(op) && gc_refs > 0) {
+        if (gc_is_unreachable(op) && gc_refs_count > 0) {
             // Clear the unreachable flag on any transitively reachable objects
             // from this one.
             any_resurrected = true;

--- a/Python/uniqueid.c
+++ b/Python/uniqueid.c
@@ -181,8 +181,8 @@ _PyObject_MergePerThreadRefcounts(_PyThreadStateImpl *tstate)
         Py_ssize_t refcnt = tstate->refcounts.values[i];
         if (refcnt != 0) {
             PyObject *obj = pool->table[i].obj;
-            _Py_atomic_add_ssize(&obj->ob_ref_shared,
-                                 refcnt << _Py_REF_SHARED_SHIFT);
+            _Py_atomic_add_int32(&obj->ob_ref_shared,
+                                 _Py_STATIC_CAST(int32_t, refcnt << _Py_REF_SHARED_SHIFT));
             tstate->refcounts.values[i] = 0;
         }
     }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a core object-header and free-threaded refcount/GC change touching every `Py_INCREF`/`Py_DECREF` and collection paths; regressions could cause use-after-free, false GC retention, or mis-immortalization despite extensive new tests.
> 
> **Overview**
> For **Py_GIL_DISABLED** only, this reshapes the `PyObject` header and threads those changes through refcounting, GC, and atomics.
> 
> **Header layout:** `ob_ref_local` shrinks from 32 bits to **8 bits** (`uint8_t`); `ob_ref_shared` shrinks from pointer-sized **`Py_ssize_t`** to **`int32_t`** (signed for biased refcounting). A new **`gc_scratch`** (`uint32_t`) holds per-object incoming-reference counts during cyclic GC, replacing a **`_Py_hashtable_t`** side table. Fields are reordered so **`ob_type`** follows the two 4-byte fields; **`sizeof(PyObject)` stays 32 bytes** on 64-bit.
> 
> **Refcount semantics:** Immortality moves from saturating **`ob_ref_local`** to a reserved range in **`ob_ref_shared`** (`_Py_REF_SHARED_IMMORTAL`, `_Py_IMMORTAL_MINIMUM_SHARED_REFCNT`), with **`static_assert`** margin above **`_Py_REF_DEFERRED`** so deferred-refcounted objects are not born immortal. Owner-thread **`Py_INCREF`/`Py_DECREF`** loads **`ob_ref_local`** in parallel with the ownership check; when local count would exceed **255**, excess **spills into `ob_ref_shared`** instead of immortalizing. Shared refcount paths use **`int32_t`** atomics (`_Py_atomic_*_int32_*`).
> 
> **GC:** `handle_resurrected_objects()` uses a two-pass algorithm on **`gc_scratch`** instead of repurposing **`ob_ref_local`** or immortalizing on huge refcounts.
> 
> Tests and docs cover spill behavior, large cross-ref cycles, pinned **`SIZEOF_PYOBJECT`**, and skipping overflow-immortality tests on free-threaded builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef65bb7e6f0359398d149e7a8dff820d6a72d95a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->